### PR TITLE
feat: export entry as a reactive prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ npm i -D svelte-intersection-observer
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
+  let entry = {};
   let element;
-  let inView;
+
+  $: inView = entry.isIntersecting;
 </script>
 
 <header>
@@ -37,15 +39,9 @@ npm i -D svelte-intersection-observer
   </div>
 </header>
 
-<IntersectionObserver
-  {element}
-  let:intersecting
-  on:observe={({ detail }) => {
-    inView = detail.isIntersecting;
-  }}
->
+<IntersectionObserver {element} bind:entry>
   <div class="element" bind:this="{element}">
-    {#if intersecting}
+    {#if inView}
       Element is in view
     {/if}
   </div>
@@ -56,14 +52,14 @@ npm i -D svelte-intersection-observer
 
 ### Props
 
-| Property name | Description                               | Value                                                                                                               |
-| :------------ | :---------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| element       | Element observed for intersection         | `HTMLElement`                                                                                                       |
-| root          | Containing element                        | `null` or `HTMLElement` (default: `null`)                                                                           |
-| rootMargin    | Offset of the containing element          | `string` (default: `"0px"`)                                                                                         |
-| threshold     | Percentage of element to trigger an event | `number` between 0 and 1 (default: `0`)                                                                             |
-| intersecting  | If the element is intersecting            | `boolean`                                                                                                           |
-| entry         | Observed element metadata                 | `null` or [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
+| Property name | Description                               | Value                                                                                                     |
+| :------------ | :---------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
+| element       | Element observed for intersection         | `HTMLElement`                                                                                             |
+| root          | Containing element                        | `null` or `HTMLElement` (default: `null`)                                                                 |
+| rootMargin    | Offset of the containing element          | `string` (default: `"0px"`)                                                                               |
+| threshold     | Percentage of element to trigger an event | `number` between 0 and 1 (default: `0`)                                                                   |
+| intersecting  | If the element is intersecting            | `boolean`                                                                                                 |
+| entry         | Observed element metadata                 | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
 
 ### Dispatched Events
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,25 +7,8 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css"
       rel="stylesheet"
     />
+    <title>svelte-intersection-observer</title>
     <style>
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }
-
-      html {
-        font-size: 24px;
-        line-height: 1.5;
-      }
-
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, Roboto, Helvetica,
-          sans-serif;
-        letter-spacing: 0.01rem;
-        overflow-y: scroll;
-      }
-
       .code-fence {
         overflow-y: scroll;
         height: 380px;

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -17,11 +17,13 @@
   export let rootMargin = "0px";
   export let threshold = 0;
 
+  /** @type {{} | Entry} */
+  export let entry = null;
+
   import { tick, createEventDispatcher, onDestroy, afterUpdate } from "svelte";
 
   const dispatch = createEventDispatcher();
-
-  let entry = null;
+  
   let intersecting = false;
   let prevElement = null;
 
@@ -32,9 +34,7 @@
 
     if (element != null && element != prevElement) {
       observer.observe(element);
-
       if (prevElement != null) observer.unobserve(prevElement);
-
       prevElement = element;
     }
   });

--- a/test.svelte
+++ b/test.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let element = undefined;
-  let inView = false;
+  let entry: { isIntersecting?: boolean; } = {};
+  let element: HTMLElement;
+
+  $: inView = entry.isIntersecting;
 </script>
 
 <header>
@@ -13,13 +15,10 @@
   </div>
 </header>
 
-<IntersectionObserver
-  {element}
-  let:intersecting
-  on:observe={({ detail }) => {
-    inView = detail.isIntersecting;
-  }}>
-  <div bind:this={element}>
-    {#if intersecting}Element is in view{/if}
+<IntersectionObserver {element} bind:entry>
+  <div class="element" bind:this="{element}">
+    {#if inView}
+      Element is in view
+    {/if}
   </div>
 </IntersectionObserver>

--- a/types/IntersectionObserver.d.ts
+++ b/types/IntersectionObserver.d.ts
@@ -22,6 +22,11 @@ export interface IntersectionObserverProps {
    * @default 0
    */
   threshold?: number;
+
+  /**
+   * @default null
+   */
+  entry?: {} | Entry;
 }
 
 export default class IntersectionObserver {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,1 @@
-export { default } from "./IntersectionObserver";
+export { default as default } from "./IntersectionObserver";


### PR DESCRIPTION
This allows the consumer to bind directly on the `entry` prop ("the Svelte way").

The resulting code is more concise:

```svelte
<script>
  import IntersectionObserver from "svelte-intersection-observer";

  let entry = {};
  let element;

  $: inView = entry.isIntersecting;
</script>

<header>
  <strong>Scroll down.</strong>
  <div>
    Element in view?
    <strong class="answer" class:inView>{inView ? 'Yes' : 'No'}</strong>
  </div>
</header>

<IntersectionObserver {element} bind:entry>
  <div class="element" bind:this="{element}">
    {#if inView}
      Element is in view
    {/if}
  </div>
</IntersectionObserver>
```