### PR TITLE
Remove observer from module context

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,21 @@ npm i -D svelte-intersection-observer
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let entry;
   let element;
-
-  $: inView = entry && entry.isIntersecting;
+  let intersecting;
 </script>
 
 <header>
   <strong>Scroll down.</strong>
   <div>
     Element in view?
-    <strong class="answer" class:inView>{inView ? 'Yes' : 'No'}</strong>
+    <strong class:intersecting>{intersecting ? 'Yes' : 'No'}</strong>
   </div>
 </header>
 
-<IntersectionObserver {element} bind:entry>
-  <div class="element" bind:this="{element}">
-    {#if inView}
-      Element is in view
-    {/if}
+<IntersectionObserver {element} bind:intersecting>
+  <div bind:this={element}>
+    {#if intersecting}Element is in view{/if}
   </div>
 </IntersectionObserver>
 ```
@@ -48,14 +44,15 @@ npm i -D svelte-intersection-observer
 
 ### Props
 
-| Prop name    | Description                               | Value                                                                                                     |
-| :----------- | :---------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
-| element      | Element observed for intersection         | `HTMLElement`                                                                                             |
-| root         | Containing element                        | `null` or `HTMLElement` (default: `null`)                                                                 |
-| rootMargin   | Offset of the containing element          | `string` (default: `"0px"`)                                                                               |
-| threshold    | Percentage of element to trigger an event | `number` between 0 and 1 (default: `0`)                                                                   |
-| intersecting | If the element is intersecting            | `boolean`                                                                                                 |
-| entry        | Observed element metadata                 | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
+| Prop name    | Description                                                 | Value                                                                                                     |
+| :----------- | :---------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
+| element      | Element observed for intersection                           | `HTMLElement`                                                                                             |
+| root         | Containing element                                          | `null` or `HTMLElement` (default: `null`)                                                                 |
+| rootMargin   | Offset of the containing element                            | `string` (default: `"0px"`)                                                                               |
+| threshold    | Percentage of element to trigger an event                   | `number` between 0 and 1 (default: `0`)                                                                   |
+| intersecting | If the element is intersecting                              | `boolean`                                                                                                 |
+| entry        | Observed element metadata                                   | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
+| intersecting | `true` if the observed element is intersecting the viewport | `boolean`                                                                                                 |
 
 ### Dispatched events
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,7 +28,7 @@ export default () => {
           background-color: #e0f7f6;
         }
 
-        .element {
+        .code-fence header ~ div {
           margin-top: calc(380px);
           height: 200px;
           padding: 1rem;
@@ -36,11 +36,11 @@ export default () => {
           color: #fff;
         }
 
-        .answer {
+        .code-fence header div strong {
           color: #d54309;
         }
 
-        .answer.inView {
+        .code-fence header div strong.intersecting {
           color: #00a91c;
         }
       `,

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  let observer = undefined;
-</script>
-
 <script>
   /**
    * @typedef {null | IntersectionObserverEntry} Entry
@@ -17,15 +13,16 @@
   export let rootMargin = "0px";
   export let threshold = 0;
 
-  /** @type {{} | Entry} */
+  /** @type {null | Entry} */
   export let entry = null;
+  export let intersecting = false;
 
   import { tick, createEventDispatcher, onDestroy, afterUpdate } from "svelte";
 
   const dispatch = createEventDispatcher();
-  
-  let intersecting = false;
+
   let prevElement = null;
+  let observer = undefined;
 
   afterUpdate(async () => {
     if (entry != null) dispatch("observe", entry);

--- a/types/IntersectionObserver.d.ts
+++ b/types/IntersectionObserver.d.ts
@@ -27,7 +27,12 @@ export interface IntersectionObserverProps {
   /**
    * @default null
    */
-  entry?: {} | Entry;
+  entry?: null | Entry;
+
+  /**
+   * @default false
+   */
+  intersecting?: boolean;
 }
 
 export default class IntersectionObserver extends SvelteComponentTyped<


### PR DESCRIPTION
#7

- feat: export intersecting prop
- fix: remove observer from module context to allow multiple instantiations
- fix prop type for `entry`