### PR TITLE
expose observer and once prop for more control over IO instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm i -D svelte-intersection-observer
 
 ## Usage
 
+### Basic
+
 <!-- prettier-ignore-start -->
 ```svelte
 <script>
@@ -35,28 +37,24 @@ npm i -D svelte-intersection-observer
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 ```
+<!-- prettier-ignore-end -->
 
-Working with dispatched events
-```svelte
-<script>
-  import IntersectionObserver from "svelte-intersection-observer";
+### on:intersect event
 
-  let element;
-  let observer;
+The "intersect" event is dispatched only if the observed element is intersecting the viewport.
 
-  const onIntersectHandler = (entry) => {
-    if (someCondition) {
-      observer.unobserve(entry.details.target);
-    }
-  }
-</script>
-
-<IntersectionObserver {element} bind:observer on:intersect={onIntersectHandler}>
+<!-- prettier-ignore-start -->
+```html
+<IntersectionObserver
+  {element}
+  on:intersect="{(e) => {
+    console.log(e.detail); // IntersectionObserverEntry
+  }}"
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 ```
 <!-- prettier-ignore-end -->
-
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -35,24 +35,48 @@ npm i -D svelte-intersection-observer
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 ```
+
+Working with dispatched events
+```svelte
+<script>
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element;
+  let observer;
+
+  const onIntersectHandler = (entry) => {
+    if (someCondition) {
+      observer.unobserve(entry.details.target);
+    }
+  }
+</script>
+
+<IntersectionObserver {element} bind:observer on:intersect={onIntersectHandler}>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+```
 <!-- prettier-ignore-end -->
+
 
 ## API
 
 ### Props
 
-| Prop name    | Description                                                 | Value                                                                                                     |
-| :----------- | :---------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
-| element      | Element observed for intersection                           | `HTMLElement`                                                                                             |
-| root         | Containing element                                          | `null` or `HTMLElement` (default: `null`)                                                                 |
-| rootMargin   | Offset of the containing element                            | `string` (default: `"0px"`)                                                                               |
-| threshold    | Percentage of element to trigger an event                   | `number` between 0 and 1 (default: `0`)                                                                   |
-| entry        | Observed element metadata                                   | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
-| intersecting | `true` if the observed element is intersecting the viewport | `boolean`                                                                                                 |
+| Prop name    | Description                                                       | Value                                                                                                     |
+| :----------- | :---------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------- |
+| element      | Element observed for intersection                                 | `HTMLElement`                                                                                             |
+| root         | Containing element                                                | `null` or `HTMLElement` (default: `null`)                                                                 |
+| rootMargin   | Offset of the containing element                                  | `string` (default: `"0px"`)                                                                               |
+| threshold    | Percentage of element to trigger an event                         | `number` between 0 and 1 (default: `0`)                                                                   |
+| entry        | Observed element metadata                                         | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
+| once         | If `true`, the observed element will be unobserved upon intersect | `boolean` (default: `false`)                                                                              |
+| intersecting | `true` if the observed element is intersecting the viewport       | `boolean` (default: `false`)                                                                              |
+| observer     | IntersectionObserver instance                                     | [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)           |
 
 ### Dispatched events
 
 - **on:observe**: fired when an intersection change occurs (type `IntersectionObserverEntry`)
+- **on:intersect**: fired when an intersection change occurs and the element is intersecting (type `IntersectionObserverEntry`)
 
 ## TypeScript support
 

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -7,6 +7,7 @@
 
   /** @type {null | HTMLElement} */
   export let element = null;
+  export let once = false;
 
   /** @type {null | HTMLElement} */
   export let root = null;
@@ -16,22 +17,32 @@
   /** @type {null | Entry} */
   export let entry = null;
   export let intersecting = false;
+  /** @type {null | IntersectionObserver} */
+  export let observer = null;
 
   import { tick, createEventDispatcher, onDestroy, afterUpdate } from "svelte";
 
   const dispatch = createEventDispatcher();
 
   let prevElement = null;
-  let observer = undefined;
 
   afterUpdate(async () => {
-    if (entry != null) dispatch("observe", entry);
+    if (entry !== null) {
+      dispatch("observe", entry);
+
+      if (entry.isIntersecting) {
+        dispatch("intersect", entry);
+
+        if (once) observer.unobserve(entry.target);
+      }
+    }
 
     await tick();
 
-    if (element != null && element != prevElement) {
+    if (element !== null && element !== prevElement) {
       observer.observe(element);
-      if (prevElement != null) observer.unobserve(prevElement);
+
+      if (prevElement !== null) observer.unobserve(prevElement);
       prevElement = element;
     }
   });
@@ -53,4 +64,4 @@
   }
 </script>
 
-<slot {intersecting} {entry} />
+<slot {intersecting} {entry} {observer} />

--- a/test.svelte
+++ b/test.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import IntersectionObserver from "./types";
+  import SvelteIntersectionObserver from "./types";
   import type { Entry } from "./types/IntersectionObserver";
 
   let intersecting = false;
   let entry: Entry = null;
   let element: HTMLElement;
+  let observer: IntersectionObserver;
 
   $: inView = entry && entry.isIntersecting;
 </script>
@@ -17,8 +18,18 @@
   </div>
 </header>
 
-<IntersectionObserver {element} bind:entry bind:intersecting>
+<SvelteIntersectionObserver {element} bind:entry bind:intersecting>
   <div class="element" bind:this={element}>
     {#if inView}Element is in view{/if}
   </div>
-</IntersectionObserver>
+</SvelteIntersectionObserver>
+
+<SvelteIntersectionObserver
+  {element}
+  bind:observer
+  on:intersect={(e) => {
+    console.log(e.detail);
+  }}
+>
+  <div bind:this={element}>Hello world</div>
+</SvelteIntersectionObserver>

--- a/types/IntersectionObserver.d.ts
+++ b/types/IntersectionObserver.d.ts
@@ -33,10 +33,20 @@ export interface IntersectionObserverProps {
    * @default false
    */
   intersecting?: boolean;
+
+  /**
+   * @default null
+   */
+  observer?: null | IntersectionObserver;
+
+  /**
+   * @default false
+   */
+  once?: boolean;
 }
 
 export default class IntersectionObserver extends SvelteComponentTyped<
   IntersectionObserverProps,
-  { observe: CustomEvent<Entry> },
-  { default: { intersecting: boolean; entry: Entry } }
+  { observe: CustomEvent<Entry>, intersect: CustomEvent<Entry> },
+  { default: { intersecting: boolean; entry: Entry; observer: IntersectionObserver; } }
 > {}

--- a/types/IntersectionObserver.d.ts
+++ b/types/IntersectionObserver.d.ts
@@ -45,8 +45,14 @@ export interface IntersectionObserverProps {
   once?: boolean;
 }
 
-export default class IntersectionObserver extends SvelteComponentTyped<
+export default class SvelteIntersectionObserver extends SvelteComponentTyped<
   IntersectionObserverProps,
-  { observe: CustomEvent<Entry>, intersect: CustomEvent<Entry> },
-  { default: { intersecting: boolean; entry: Entry; observer: IntersectionObserver; } }
+  { observe: CustomEvent<Entry>; intersect: CustomEvent<Entry> },
+  {
+    default: {
+      intersecting: boolean;
+      entry: Entry;
+      observer: IntersectionObserver;
+    };
+  }
 > {}


### PR DESCRIPTION
This PR includes a couple of enhancements that do not impact the current interface.

Changes include:
- Exposing the `IntersectionObserver` instance via `observer` which will allow more control over the IO instance.
- Adds a new dispatch event `intersect` for intersecting only events. 
- New `once` attribute that will `unobserve` once the element(s) have met the intersection threshold.
- Use strict equality checks where it makes sense

Using `once`:
```svelte
<IntersectionObserver once={true} {element}>
  <div bind:this={element}>Hello world</div>
</IntersectionObserver>
````

Using `interesect` and stop watching using `unobserve` with `observer`:
```svelte
<script>
  import IntersectionObserver from "svelte-intersection-observer";
  
  let element;
  let observer;

  const onIntersectHandler = (entry) => {
    if (someCondition) {
      observer.unobserve(entry.details.target); // or (element)
    }
  }
</script>

<IntersectionObserver {element} bind:observer on:intersect={onIntersectHandler}>
  <div bind:this={element}>Hello world</div>
</IntersectionObserver>
````