### PR TITLE
support dynamically changing the rootMargin

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -49,6 +49,7 @@
 
   const dispatch = createEventDispatcher();
 
+  let prevRootMargin = null;
   let prevElement = null;
 
   afterUpdate(async () => {
@@ -58,7 +59,7 @@
       if (entry.isIntersecting) {
         dispatch("intersect", entry);
 
-        if (once) observer.unobserve(entry.target);
+        if (once) observer.unobserve(element);
       }
     }
 
@@ -70,13 +71,21 @@
       if (prevElement !== null) observer.unobserve(prevElement);
       prevElement = element;
     }
+
+    if (prevRootMargin && rootMargin !== prevRootMargin) {
+      observer.disconnect();
+      prevElement = null;
+      initialize();
+    }
+
+    prevRootMargin = rootMargin;
   });
 
   onDestroy(() => {
     if (observer) observer.disconnect();
   });
 
-  $: if (typeof window !== "undefined") {
+  const initialize = () => {
     observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((_entry) => {
@@ -86,6 +95,12 @@
       },
       { root, rootMargin, threshold }
     );
+  }
+
+  $: {
+    if (typeof window !== "undefined") {
+      initialize();
+    }
   }
 </script>
 


### PR DESCRIPTION
Allows for updating `rootMargin` after init to accommodate scrolling, zooming, network, etc. changes.

There's a discussion happening around this currently with the W3C IO Spec. It sounds like it will eventually be supported, but is not something currently provided.

https://github.com/w3c/IntersectionObserver/issues/428

Thoughts?