### PR TITLE
Improve TypeScript definitions for dispatched events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies and build the library
+        run: |
+          yarn
+          yarn prepack
+      - name: Validate the TypeScript definitions
+        run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js: 14
-cache: yarn
-script:
-  - yarn prepack
-  - yarn test

--- a/test/IntersectionObserver.test.svelte
+++ b/test/IntersectionObserver.test.svelte
@@ -39,7 +39,12 @@
 
 <!-- svelte-ignore missing-declaration -->
 <IO
-  on:intersect={(e) => {
+  on:observe={(e) => {
     console.log(e.detail);
+    console.log(e.detail.intersectionRect);
+    console.log(e.detail.isIntersecting); // boolean
+  }}
+  on:intersect={(e) => {
+    console.log(e.detail.isIntersecting); // true
   }}
 />

--- a/types/IntersectionObserver.svelte.d.ts
+++ b/types/IntersectionObserver.svelte.d.ts
@@ -47,7 +47,21 @@ export interface IntersectionObserverProps {
 
 export default class SvelteIntersectionObserver extends SvelteComponentTyped<
   IntersectionObserverProps,
-  { observe: CustomEvent<Entry>; intersect: CustomEvent<Entry> },
+  {
+    /**
+     * Dispatched when the element is first observed
+     * and also whenever an intersection event occurs.
+     */
+    observe: CustomEvent<IntersectionObserverEntry>;
+
+    /**
+     * Dispatched only when the element is intersecting the viewport.
+     * `event.detail.isIntersecting` will only be `true`
+     */
+    intersect: CustomEvent<
+      IntersectionObserverEntry & { isIntersecting: true }
+    >;
+  },
   {
     default: {
       intersecting: boolean;


### PR DESCRIPTION
**Features**

- improve TypeScript definitions for dispatched events
  - `on:observe`: `event.detail.isIntersecting` is a `boolean`
  - `on:intersect`: `event.detail.isIntersecting` can only be `true`