### PR TITLE
Add prop descriptions to TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ As an alternative to binding the `intersecting` prop, you can listen to the `int
 
 The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
 
-Note that all properties in `IntersectionObserverEntry` are read only.
+Note that all properties in `IntersectionObserverEntry` are read-only.
 
 <details>
  <summary><code>IntersectionObserverEntry</code></summary>

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,41 +1,49 @@
 <script>
   /**
-   * The HTML Element to observe
+   * The HTML Element to observe.
    * @type {null | HTMLElement}
    */
   export let element = null;
 
   /**
-   * Set to `true` to unobserve the element after it intersects the viewport
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
    * @type {boolean}
    */
   export let once = false;
 
   /**
-   * Containing element
-   * Defaults to the browser viewport
+   * `true` if the observed element
+   * is intersecting the viewport.
+   */
+  export let intersecting = false;
+
+  /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
    * @type {null | HTMLElement}
    */
   export let root = null;
 
-  /** Margin offset of the containing element */
+  /** Margin offset of the containing element. */
   export let rootMargin = "0px";
 
   /**
-   * Percentage of element visibility to trigger an event
-   * Value must be between 0 and 1
+   * Percentage of element visibility to trigger an event.
+   * Value must be between 0 and 1.
    */
   export let threshold = 0;
 
-  /** @type {null | IntersectionObserverEntry} */
+  /**
+   * Observed element metadata.
+   * @type {null | IntersectionObserverEntry}
+   */
   export let entry = null;
 
   /**
-   * `true` is the observed element is intersecting the element
+   * `IntersectionObserver` instance.
+   * @type {null | IntersectionObserver}
    */
-  export let intersecting = false;
-
-  /** @type {null | IntersectionObserver} */
   export let observer = null;
 
   import { tick, createEventDispatcher, afterUpdate, onMount } from "svelte";

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,7 +1,7 @@
 <script>
   /**
    * The HTML Element to observe.
-   * @type {null | HTMLElement}
+   * @type {HTMLElement}
    */
   export let element = null;
 
@@ -21,7 +21,7 @@
   /**
    * Specify the containing element.
    * Defaults to the browser viewport.
-   * @type {null | HTMLElement}
+   * @type {HTMLElement}
    */
   export let root = null;
 

--- a/types/IntersectionObserver.svelte.d.ts
+++ b/types/IntersectionObserver.svelte.d.ts
@@ -5,44 +5,56 @@ export type Entry = null | IntersectionObserverEntry;
 
 export interface IntersectionObserverProps {
   /**
+   * The HTML Element to observe.
    * @default null
    */
   element?: null | HTMLElement;
 
   /**
-   * @default null
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
+   * @default false
    */
-  root?: null | HTMLElement;
+  once?: boolean;
 
   /**
-   * @default "0px"
-   */
-  rootMargin?: string;
-
-  /**
-   * @default 0
-   */
-  threshold?: number;
-
-  /**
-   * @default null
-   */
-  entry?: null | Entry;
-
-  /**
+   * `true` if the observed element
+   * is intersecting the viewport.
    * @default false
    */
   intersecting?: boolean;
 
   /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
+   * @default null
+   */
+  root?: null | HTMLElement;
+
+  /**
+   * Margin offset of the containing element.
+   * @default "0px"
+   */
+  rootMargin?: string;
+
+  /**
+   * Percentage of element visibility to trigger an event.
+   * Value must be between 0 and 1.
+   * @default 0
+   */
+  threshold?: number;
+
+  /**
+   * Observed element metadata.
+   * @default null
+   */
+  entry?: null | Entry;
+
+  /**
+   * `IntersectionObserver` instance.
    * @default null
    */
   observer?: null | IntersectionObserver;
-
-  /**
-   * @default false
-   */
-  once?: boolean;
 }
 
 export default class SvelteIntersectionObserver extends SvelteComponentTyped<

--- a/types/IntersectionObserver.svelte.d.ts
+++ b/types/IntersectionObserver.svelte.d.ts
@@ -8,7 +8,7 @@ export interface IntersectionObserverProps {
    * The HTML Element to observe.
    * @default null
    */
-  element?: null | HTMLElement;
+  element?: HTMLElement;
 
   /**
    * Set to `true` to unobserve the element
@@ -29,7 +29,7 @@ export interface IntersectionObserverProps {
    * Defaults to the browser viewport.
    * @default null
    */
-  root?: null | HTMLElement;
+  root?: HTMLElement;
 
   /**
    * Margin offset of the containing element.


### PR DESCRIPTION
- make JSDoc prop descriptions consistent with the docs
- add prop descriptions to the TypeScript definitions
- remove redundant `null` in `null | HTMLElement` types