### PR TITLE
Update threshold type to match spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ As an alternative to binding the `intersecting` prop, you can listen to the `int
 | intersecting | `true` if the observed element is intersecting the viewport | `boolean`                                                                                                 | `false`       |
 | root         | Containing element                                          | `null` or `HTMLElement`                                                                                   | `null`        |
 | rootMargin   | Margin offset of the containing element                     | `string`                                                                                                  | `"0px"`       |
-| threshold    | Percentage of element visibile to trigger an event          | `number` between 0 and 1                                                                                  | `0`           |
+| threshold    | Percentage of element visibile to trigger an event          | `number` between 0 and 1, or an array of `number`s between 0 and 1                                        | `0`           |
 | entry        | Observed element metadata                                   | [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | `null`        |
 | observer     | `IntersectionObserver` instance                             | [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)           | `null`        |
 

--- a/types/IntersectionObserver.svelte.d.ts
+++ b/types/IntersectionObserver.svelte.d.ts
@@ -39,10 +39,10 @@ export interface IntersectionObserverProps {
 
   /**
    * Percentage of element visibility to trigger an event.
-   * Value must be between 0 and 1.
+   * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
    * @default 0
    */
-  threshold?: number;
+  threshold?: number | number[];
 
   /**
    * Observed element metadata.


### PR DESCRIPTION
The threshold can also be an array of numbers: 
https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold

The `threshold` attr is passed to the `IntersectionObserver` constructor untouched [see here](https://github.com/metonym/svelte-intersection-observer/blob/master/src/IntersectionObserver.svelte#L64), so this already works, eg:
https://svelte.dev/repl/8678c81cba1142aa8b788bb5dd991968?version=4.1.0
