### PR TITLE
chore: document 0.10.2 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2](https://github.com/metonym/svelte-intersection-observer/releases/tag/v0.10.2) - 2024-01-01
+
+**Fixes**
+
+- add `exports` field to `package.json`
+
 ## [0.10.1](https://github.com/metonym/svelte-intersection-observer/releases/tag/v0.10.1) - 2023-07-20
 
 **Fixes**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-intersection-observer",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "MIT",
   "description": "Detect if an element is in the viewport using the Intersection Observer API",
   "author": "Eric Liu (https://github.com/metonym)",


### PR DESCRIPTION
A fix for adding the `exports` map to `package.json` was [backported](https://github.com/metonym/svelte-intersection-observer/tree/v0.10/exports-map) in v0.10.2. 

One reason for the backport is that the current `master` branch contains breaking changes that are unreleased. By design, we want to introduce this as a SemVer patch so consumers on `v0.10.x` can get the fix.

This PR updates the existing package metadata to reflect this backport fix.