### PR TITLE
fix: dispatch observe/intersect from observer callback, not afterUpdate

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -62,6 +62,14 @@
         entries.forEach((_entry) => {
           entry = _entry;
           intersecting = _entry.isIntersecting;
+
+          dispatch("observe", entry);
+
+          if (_entry.isIntersecting) {
+            dispatch("intersect", entry);
+
+            if (element && once) observer?.unobserve(element);
+          }
         });
       },
       { root, rootMargin, threshold },
@@ -80,16 +88,6 @@
   });
 
   afterUpdate(async () => {
-    if (entry !== null) {
-      dispatch("observe", entry);
-
-      if (entry.isIntersecting) {
-        dispatch("intersect", entry);
-
-        if (element && once) observer?.unobserve(element);
-      }
-    }
-
     await tick();
 
     if (element !== null && element !== prevElement) {

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -32,6 +32,31 @@ test("Once", async ({ mount, page }) => {
   await expect(component).toHaveText(/Hello world/);
 });
 
+test("Once - does not re-dispatch intersect on unrelated updates", async ({
+  mount,
+  page,
+}) => {
+  await mount(Once);
+
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 0/,
+  );
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+
+  await page.getByTestId("unrelated-button").click();
+  await page.getByTestId("unrelated-button").click();
+  await page.getByTestId("unrelated-button").click();
+
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+});
+
 test("Root margin", async ({ mount, page }) => {
   const component = await mount(RootMargin);
 

--- a/tests/Once.svelte
+++ b/tests/Once.svelte
@@ -3,13 +3,24 @@
 
   let element: null | HTMLDivElement = null;
   let intersecting = false;
+  let intersectCount = 0;
+  let unrelated = 0;
 </script>
 
 <header class:intersecting>
   {intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
+  <button data-testid="unrelated-button" on:click={() => (unrelated += 1)}>
+    Unrelated: {unrelated}
+  </button>
 </header>
 
-<IntersectionObserver {element} bind:intersecting once>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  once
+  on:intersect={() => (intersectCount += 1)}
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 


### PR DESCRIPTION
Fixes #91.

afterUpdate runs on every render, not just when the IntersectionObserver produces a new entry, so observe and intersect were re-dispatched on unrelated component updates. This also meant once didn't reliably stop re-firing intersect.

Moves the dispatch (and the once unobserve call) into the IntersectionObserver callback itself, matching the pattern already used in MultipleIntersectionObserver.svelte.

Added a regression test: trigger a real intersection with once, then force unrelated re-renders, and assert intersect only fired once.