### PR TITLE
docs: add examples for scroll-to-end, #each usage, and threshold sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ This avoids instantiating a new observer for every element.
 | entry        | Observed element metadata                                   | `null` or [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | `null`        |
 | observer     | `IntersectionObserver` instance                             | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)           | `null`        |
 
+**Note**: the observed `element` must render with a non-zero width and height for `threshold` values greater than `0` to have any effect — this is a constraint of the underlying [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API), not something this component controls.
+
 #### Dispatched events
 
 - **on:observe**: fired when the element is first observed or whenever an intersection change occurs

--- a/README.md
+++ b/README.md
@@ -136,6 +136,38 @@ As an alternative to binding the `intersecting` prop, you can listen to the `int
 </IntersectionObserver>
 ```
 
+### Detecting scroll to end
+
+To detect when a user has scrolled to the end of a scrollable container, place a sentinel element after the content and set `root` to the container. `intersecting` becomes `true` once the sentinel scrolls into view.
+
+```svelte
+<script>
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let container;
+  let sentinel;
+  let reachedEnd;
+</script>
+
+<header class:intersecting={reachedEnd}>
+  {reachedEnd ? "You've reached the end" : "Keep scrolling..."}
+</header>
+
+<div bind:this={container} style:height="auto">
+  {#each Array.from({ length: 20 }) as _, i}
+    <p>Paragraph {i + 1}</p>
+  {/each}
+
+  <IntersectionObserver
+    element={sentinel}
+    root={container}
+    bind:intersecting={reachedEnd}
+  >
+    <div bind:this={sentinel} style="height: 1px;" />
+  </IntersectionObserver>
+</div>
+```
+
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,47 @@ This avoids instantiating a new observer for every element.
 </MultipleIntersectionObserver>
 ```
 
+### Using with `#each`
+
+`MultipleIntersectionObserver` also handles a dynamic, `#each`-driven list — give every item its own slot in an array/object instead of one shared variable.
+
+```svelte
+<script>
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let items = [
+    { id: 1, text: "Item 1" },
+    { id: 2, text: "Item 2" },
+    { id: 3, text: "Item 3" },
+  ];
+
+  let refs = [];
+  let itemsContainer;
+
+  $: itemElements = refs;
+</script>
+
+<MultipleIntersectionObserver
+  elements={itemElements}
+  root={itemsContainer}
+  let:elementIntersections
+>
+  <header>
+    {#each items as item, i}
+      <div class:intersecting={elementIntersections.get(refs[i])}>
+        {item.text}: {elementIntersections.get(refs[i]) ? "✓" : "✗"}
+      </div>
+    {/each}
+  </header>
+
+  <div bind:this={itemsContainer}>
+    {#each items as item, i (item.id)}
+      <div bind:this={refs[i]}>{item.text}</div>
+    {/each}
+  </div>
+</MultipleIntersectionObserver>
+```
+
 ## API
 
 ### IntersectionObserver

--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ This avoids instantiating a new observer for every element.
 </MultipleIntersectionObserver>
 ```
 
+**Avoid** using the single-element `IntersectionObserver` component inside an `#each` block with one variable shared across iterations (e.g. `let node;` declared outside the loop and bound via `bind:this={node}` inside it). Every iteration overwrites the same `node`, so each observer instance keeps re-observing a moving target, which can produce an infinite update loop. Use `MultipleIntersectionObserver` with a per-item ref, as shown above, instead.
+
 ## API
 
 ### IntersectionObserver


### PR DESCRIPTION
Adds four small README additions surfaced by issue triage: a scroll-to-end detection example, an `#each` loop example for `MultipleIntersectionObserver`, a warning against sharing one bound element across `#each` iterations, and a note on the minimum element size needed for `threshold` to take effect. Each change is its own commit for easier review. No source code changes are included.

Closes #92, Closes #63, Closes #69, Closes #37