### PR TITLE
Add missing test coverage for props, once, root, threshold, and dynamic retargeting

### DIFF
--- a/tests/ElementChange.svelte
+++ b/tests/ElementChange.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let elementB: null | HTMLDivElement = null;
+  let intersecting = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button data-testid="switch" on:click={() => (element = elementB)}>
+    Switch
+  </button>
+</header>
+
+<IntersectionObserver {element} bind:intersecting>
+  <div data-testid="element-a" bind:this={element}>A</div>
+</IntersectionObserver>
+
+<div data-testid="element-b" bind:this={elementB}>B</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  [data-testid="element-a"] {
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+
+  [data-testid="element-b"] {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #2ecc71;
+    color: #fff;
+  }
+</style>

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -6,6 +6,7 @@ import RootMarginChange from "./RootMarginChange.svelte";
 import Multiple from "./Multiple.svelte";
 import MultipleBasic from "./MultipleBasic.svelte";
 import MultipleBinding from "./MultipleBinding.svelte";
+import MultipleOnce from "./MultipleOnce.svelte";
 import MultipleRootMarginChange from "./MultipleRootMarginChange.svelte";
 
 test.use({ viewport: { width: 1200, height: 600 } });
@@ -152,6 +153,40 @@ test("Multiple elements", async ({ mount, page }) => {
   );
   await expect(page.getByTestId("item-3-status")).toHaveText(
     /Item 3 is not visible/,
+  );
+});
+
+test("Multiple elements - once", async ({ mount, page }) => {
+  await mount(MultipleOnce);
+
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 0/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 1/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 1/,
+  );
+
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-count")).toHaveText(
+    /Item 2 intersect count: 0/,
   );
 });
 

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -2,9 +2,11 @@ import { test, expect } from "@playwright/experimental-ct-svelte";
 import Basic from "./Basic.svelte";
 import Once from "./Once.svelte";
 import RootMargin from "./RootMargin.svelte";
+import RootMarginChange from "./RootMarginChange.svelte";
 import Multiple from "./Multiple.svelte";
 import MultipleBasic from "./MultipleBasic.svelte";
 import MultipleBinding from "./MultipleBinding.svelte";
+import MultipleRootMarginChange from "./MultipleRootMarginChange.svelte";
 
 test.use({ viewport: { width: 1200, height: 600 } });
 
@@ -67,6 +69,32 @@ test("Root margin", async ({ mount, page }) => {
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
   await expect(page.locator("header")).toHaveText(/Element is in view/);
   await expect(component).toHaveText(/Hello world/);
+});
+
+test("Root margin - reinitializes the observer when changed at runtime", async ({
+  mount,
+  page,
+}) => {
+  await mount(RootMarginChange);
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("shrink-root-margin").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
+test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({
+  mount,
+  page,
+}) => {
+  await mount(MultipleRootMarginChange);
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("shrink-root-margin").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
 test("Multiple elements", async ({ mount, page }) => {

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -1,12 +1,14 @@
 import { test, expect } from "@playwright/experimental-ct-svelte";
 import Basic from "./Basic.svelte";
 import Once from "./Once.svelte";
+import Root from "./Root.svelte";
 import RootMargin from "./RootMargin.svelte";
 import RootMarginChange from "./RootMarginChange.svelte";
 import Multiple from "./Multiple.svelte";
 import MultipleBasic from "./MultipleBasic.svelte";
 import MultipleBinding from "./MultipleBinding.svelte";
 import MultipleOnce from "./MultipleOnce.svelte";
+import MultipleRoot from "./MultipleRoot.svelte";
 import MultipleRootMarginChange from "./MultipleRootMarginChange.svelte";
 import Threshold from "./Threshold.svelte";
 import MultipleThreshold from "./MultipleThreshold.svelte";
@@ -98,6 +100,41 @@ test("Multiple elements - reinitializes the observer when root margin changes at
 
   await page.getByTestId("shrink-root-margin").click();
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
+test("Root - uses a custom scroll container instead of the viewport", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(Root);
+
+  await expect(page.getByTestId("status")).toHaveText(
+    /Element is not in view/,
+  );
+
+  await page.getByTestId("container").evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+
+  await expect(page.getByTestId("status")).toHaveText(/Element is in view/);
+  await expect(component).toHaveText(/Hello world/);
+});
+
+test("Multiple elements - uses a custom scroll container instead of the viewport", async ({
+  mount,
+  page,
+}) => {
+  await mount(MultipleRoot);
+
+  await expect(page.getByTestId("status")).toHaveText(
+    /Element is not in view/,
+  );
+
+  await page.getByTestId("container").evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+
+  await expect(page.getByTestId("status")).toHaveText(/Element is in view/);
 });
 
 test("Threshold - requires a minimum visible ratio before intersecting", async ({

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/experimental-ct-svelte";
 import Basic from "./Basic.svelte";
+import ElementChange from "./ElementChange.svelte";
 import Once from "./Once.svelte";
 import Root from "./Root.svelte";
 import RootMargin from "./RootMargin.svelte";
@@ -7,6 +8,7 @@ import RootMarginChange from "./RootMarginChange.svelte";
 import Multiple from "./Multiple.svelte";
 import MultipleBasic from "./MultipleBasic.svelte";
 import MultipleBinding from "./MultipleBinding.svelte";
+import MultipleElementsChange from "./MultipleElementsChange.svelte";
 import MultipleOnce from "./MultipleOnce.svelte";
 import MultipleRoot from "./MultipleRoot.svelte";
 import MultipleRootMarginChange from "./MultipleRootMarginChange.svelte";
@@ -74,6 +76,21 @@ test("Root margin", async ({ mount, page }) => {
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
   await expect(page.locator("header")).toHaveText(/Element is in view/);
   await expect(component).toHaveText(/Hello world/);
+});
+
+test("Element - switching the observed element retargets the observer", async ({
+  mount,
+  page,
+}) => {
+  await mount(ElementChange);
+
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("switch").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
 });
 
 test("Root margin - reinitializes the observer when changed at runtime", async ({
@@ -257,6 +274,43 @@ test("Multiple elements - once", async ({ mount, page }) => {
   );
   await expect(page.getByTestId("item-2-count")).toHaveText(
     /Item 2 intersect count: 0/,
+  );
+});
+
+test("Multiple elements - elements array add/remove retargets the observer", async ({
+  mount,
+  page,
+}) => {
+  await mount(MultipleElementsChange);
+
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+
+  await page.getByTestId("add-item-2").click();
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is visible/,
+  );
+
+  await page.getByTestId("remove-item-1").click();
+  await page.evaluate(() => window.scrollTo(0, 0));
+
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
   );
 });
 

--- a/tests/IntersectionObserver.test.ts
+++ b/tests/IntersectionObserver.test.ts
@@ -8,6 +8,8 @@ import MultipleBasic from "./MultipleBasic.svelte";
 import MultipleBinding from "./MultipleBinding.svelte";
 import MultipleOnce from "./MultipleOnce.svelte";
 import MultipleRootMarginChange from "./MultipleRootMarginChange.svelte";
+import Threshold from "./Threshold.svelte";
+import MultipleThreshold from "./MultipleThreshold.svelte";
 
 test.use({ viewport: { width: 1200, height: 600 } });
 
@@ -96,6 +98,37 @@ test("Multiple elements - reinitializes the observer when root margin changes at
 
   await page.getByTestId("shrink-root-margin").click();
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
+test("Threshold - requires a minimum visible ratio before intersecting", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(Threshold);
+
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+  await page.evaluate(() => window.scrollTo(0, 550));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+  await expect(component).toHaveText(/Hello world/);
+});
+
+test("Multiple elements - threshold requires a minimum visible ratio", async ({
+  mount,
+  page,
+}) => {
+  await mount(MultipleThreshold);
+
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+  await page.evaluate(() => window.scrollTo(0, 550));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
 });
 
 test("Multiple elements", async ({ mount, page }) => {

--- a/tests/MultipleElementsChange.svelte
+++ b/tests/MultipleElementsChange.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let ref1: null | HTMLDivElement = null;
+  let ref2: null | HTMLDivElement = null;
+  let includeItem1 = true;
+  let includeItem2 = false;
+
+  $: elements = [includeItem1 ? ref1 : null, includeItem2 ? ref2 : null];
+</script>
+
+<MultipleIntersectionObserver {elements} let:elementIntersections>
+  <header>
+    <button data-testid="add-item-2" on:click={() => (includeItem2 = true)}>
+      Add item 2
+    </button>
+    <button
+      data-testid="remove-item-1"
+      on:click={() => (includeItem1 = false)}
+    >
+      Remove item 1
+    </button>
+    <p data-testid="item-1-status">
+      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-2-status">
+      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
+    </p>
+  </header>
+
+  <div style="display: flex; margin-top: calc(100vh + 1px);">
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+      style="height: 38vh; width: 50%; background-color: #376462; color: #fff;"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+      style="height: 38vh; width: 50%; background-color: #2ecc71; color: #fff;"
+    >
+      Item 2
+    </div>
+  </div>
+</MultipleIntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+</style>

--- a/tests/MultipleIntersectionObserver.test.svelte
+++ b/tests/MultipleIntersectionObserver.test.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  /**
+   * Run `bun test:types` to test the type definitions of the component using `svelte-check`.
+   */
+
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+  import type { ComponentProps } from "svelte";
+
+  type Props = ComponentProps<MultipleIntersectionObserver>;
+
+  let elements: Props["elements"] = [];
+  let elementIntersections: Props["elementIntersections"] = new Map();
+  let elementEntries: Props["elementEntries"] = new Map();
+  let observer: Props["observer"];
+
+  let ref1: null | HTMLDivElement = null;
+  let ref2: null | HTMLDivElement = null;
+
+  $: elements = [ref1, ref2];
+</script>
+
+<MultipleIntersectionObserver
+  {elements}
+  bind:observer
+  bind:elementIntersections
+  bind:elementEntries
+  on:observe={(e) => {
+    e.detail.target; // HTMLElement
+    e.detail.entry.intersectionRect; // DOMRectReadOnly
+    e.detail.entry.isIntersecting; // boolean
+  }}
+  on:intersect={(e) => {
+    e.detail.target; // HTMLElement
+    e.detail.entry.isIntersecting; // true
+  }}
+  let:elementIntersections
+  let:elementEntries
+  let:observer
+>
+  <div bind:this={ref1}>
+    {elementIntersections.get(ref1) ? "visible" : "not visible"}
+    {elementEntries.get(ref1)?.boundingClientRect}
+  </div>
+  <div bind:this={ref2}>
+    {elementIntersections.get(ref2) ? "visible" : "not visible"}
+    {elementEntries.get(ref2)?.boundingClientRect}
+  </div>
+  {observer}
+</MultipleIntersectionObserver>

--- a/tests/MultipleOnce.svelte
+++ b/tests/MultipleOnce.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let ref1: null | HTMLDivElement = null;
+  let ref2: null | HTMLDivElement = null;
+  let intersectCount1 = 0;
+  let intersectCount2 = 0;
+
+  $: elements = [ref1, ref2];
+</script>
+
+<MultipleIntersectionObserver
+  {elements}
+  once
+  let:elementIntersections
+  on:intersect={(e) => {
+    if (e.detail.target === ref1) intersectCount1 += 1;
+    if (e.detail.target === ref2) intersectCount2 += 1;
+  }}
+>
+  <header>
+    <p data-testid="item-1-status">
+      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-2-status">
+      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-1-count">Item 1 intersect count: {intersectCount1}</p>
+    <p data-testid="item-2-count">Item 2 intersect count: {intersectCount2}</p>
+  </header>
+
+  <div bind:this={ref1} data-testid="item-1">Item 1</div>
+  <div bind:this={ref2} data-testid="item-2">Item 2</div>
+</MultipleIntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    height: 50vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+    margin-bottom: 100vh;
+  }
+
+  div:first-of-type {
+    margin-top: calc(100vh + 1px);
+  }
+</style>

--- a/tests/MultipleRoot.svelte
+++ b/tests/MultipleRoot.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let container: null | HTMLDivElement = null;
+  let ref1: null | HTMLDivElement = null;
+  let elementIntersections = new Map<HTMLElement | null, boolean>();
+
+  $: elements = [ref1];
+</script>
+
+<div data-testid="status">
+  {elementIntersections.get(ref1) ? "Element is in view" : "Element is not in view"}
+</div>
+
+<div
+  bind:this={container}
+  data-testid="container"
+  style="height: 200px; overflow-y: auto;"
+>
+  <MultipleIntersectionObserver {elements} root={container} bind:elementIntersections>
+    <div
+      bind:this={ref1}
+      style="margin-top: 400px; height: 100px; background-color: #376462; color: #fff;"
+    >
+      Hello world
+    </div>
+  </MultipleIntersectionObserver>
+</div>

--- a/tests/MultipleRootMarginChange.svelte
+++ b/tests/MultipleRootMarginChange.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let ref1: null | HTMLDivElement = null;
+  let rootMargin = "0px";
+
+  $: elements = [ref1];
+</script>
+
+<MultipleIntersectionObserver {elements} {rootMargin} let:elementIntersections>
+  <header>
+    {elementIntersections.get(ref1) ? "Element is in view" : "Element is not in view"}
+    <button
+      data-testid="shrink-root-margin"
+      on:click={() => (rootMargin = "-200px")}
+    >
+      Shrink root margin
+    </button>
+  </header>
+
+  <div bind:this={ref1}>Hello world</div>
+</MultipleIntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/MultipleThreshold.svelte
+++ b/tests/MultipleThreshold.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let ref1: null | HTMLDivElement = null;
+
+  $: elements = [ref1];
+</script>
+
+<MultipleIntersectionObserver
+  {elements}
+  threshold={0.5}
+  let:elementIntersections
+>
+  <header>
+    {elementIntersections.get(ref1)
+      ? "Element is in view"
+      : "Element is not in view"}
+  </header>
+
+  <div bind:this={ref1}>Hello world</div>
+</MultipleIntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: 100vh;
+    height: 100vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/Root.svelte
+++ b/tests/Root.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let container: null | HTMLDivElement = null;
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+</script>
+
+<div data-testid="status">
+  {intersecting ? "Element is in view" : "Element is not in view"}
+</div>
+
+<div
+  bind:this={container}
+  data-testid="container"
+  style="height: 200px; overflow-y: auto;"
+>
+  <IntersectionObserver {element} root={container} bind:intersecting>
+    <div
+      bind:this={element}
+      style="margin-top: 400px; height: 100px; background-color: #376462; color: #fff;"
+    >
+      Hello world
+    </div>
+  </IntersectionObserver>
+</div>

--- a/tests/RootMarginChange.svelte
+++ b/tests/RootMarginChange.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+  let rootMargin = "0px";
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="shrink-root-margin"
+    on:click={() => (rootMargin = "-200px")}
+  >
+    Shrink root margin
+  </button>
+</header>
+
+<IntersectionObserver {element} bind:intersecting {rootMargin}>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/Threshold.svelte
+++ b/tests/Threshold.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+</header>
+
+<IntersectionObserver {element} bind:intersecting threshold={0.5}>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: 100vh;
+    height: 100vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>


### PR DESCRIPTION
This adds test coverage for previously untested public API: type-checking for MultipleIntersectionObserver, runtime rootMargin changes, once on MultipleIntersectionObserver, the threshold and root props on both components, and dynamic element/elements retargeting. Each addition is its own commit with a matching Playwright fixture and assertions. I could not execute the Playwright suite in this environment due to a sandboxing issue with the local test server, so please run it in CI before merging.