### PR TITLE
chore(biome): replace prettier with Biome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: bun ci --ignore-scripts
 
+      - name: Run Biome
+        run: bunx biome ci --error-on-warnings
+
       - name: Check types
         run: bun run test:types
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["**", "!!**/.*/**/*"]
+  },
+  "formatter": {
+    "attributePosition": "multiline",
+    "indentStyle": "space",
+    "lineWidth": 120
+  },
+  "html": {
+    "experimentalFullSupportEnabled": true,
+    "formatter": {
+      "enabled": true,
+      "indentScriptAndStyle": true
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "performance": {
+        "noAccumulatingSpread": "error",
+        "noAwaitInLoops": "error",
+        "noDelete": "error",
+        "noDynamicNamespaceImportAccess": "error",
+        "noNamespaceImport": "error",
+        "noReExportAll": "error",
+        "useTopLevelRegex": "error"
+      },
+      "complexity": {
+        "noCommaOperator": "error",
+        "noForEach": "error",
+        "noUselessConstructor": "error",
+        "noUselessEmptyExport": "error",
+        "noUselessFragments": "error",
+        "noUselessLabel": "error",
+        "noUselessLoneBlockStatements": "error",
+        "noUselessRename": "error",
+        "noUselessSwitchCase": "error",
+        "noUselessTypeConstraint": "error",
+        "useArrowFunction": "error",
+        "useLiteralKeys": "error",
+        "noImportantStyles": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noImportCycles": "error"
+      },
+      "style": {
+        "noImplicitBoolean": "error",
+        "noNegationElse": "error",
+        "noParameterAssign": "error",
+        "noRestrictedGlobals": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useDefaultParameterLast": "error",
+        "useExponentiationOperator": "error",
+        "useNodejsImportProtocol": "error",
+        "useNumberNamespace": "error",
+        "useSingleVarDeclarator": "error",
+        "noCommonJs": "error"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/e2e/fixtures/**/*"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedFunctionParameters": "off",
+            "noUnusedVariables": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
+          },
+          "a11y": {
+            "useButtonType": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/*.svg"],
+      "formatter": {
+        "enabled": false
+      }
+    },
+    {
+      "includes": ["**/e2e/**/*"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noForEach": "off"
+          },
+          "performance": {
+            "noReExportAll": "off",
+            "useTopLevelRegex": "off"
+          },
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,12 +5,11 @@
     "": {
       "name": "svelte-intersection-observer",
       "devDependencies": {
+        "@biomejs/biome": "2.5.2",
         "@playwright/test": "^1.61.1",
         "@sveltejs/vite-plugin-svelte": "^2.5.3",
         "@types/bun": "^1.3.6",
         "@typescript/native-preview": "^7.0.0-dev.20260703.1",
-        "prettier": "^3.8.0",
-        "prettier-plugin-svelte": "^3.4.1",
         "svelte": "3.59.2",
         "svelte-check": "^4.7.1",
         "svelte-readme": "^3.6.3",
@@ -23,6 +22,24 @@
     "@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
+
+    "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 
@@ -218,9 +235,9 @@
 
     "postcss": ["postcss@8.5.1", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ=="],
 
-    "prettier": ["prettier@3.8.0", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA=="],
+    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
-    "prettier-plugin-svelte": ["prettier-plugin-svelte@3.4.1", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0" } }, "sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg=="],
+    "prettier-plugin-svelte": ["prettier-plugin-svelte@2.10.1", "", { "peerDependencies": { "prettier": "^1.16.4 || ^2.0.0", "svelte": "^3.2.0 || ^4.0.0-next.0" } }, "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ=="],
 
     "prism-svelte": ["prism-svelte@0.4.7", "", {}, "sha512-yABh19CYbM24V7aS7TuPYRNMqthxwbvx6FF/Rw920YbyBWO3tnyPIqRMgHuSVsLmuHkkBS1Akyof463FVdkeDQ=="],
 
@@ -287,10 +304,6 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "rollup-plugin-svelte/@rollup/pluginutils": ["@rollup/pluginutils@4.2.1", "", { "dependencies": { "estree-walker": "^2.0.1", "picomatch": "^2.2.2" } }, "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ=="],
-
-    "svelte-readme/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
-
-    "svelte-readme/prettier-plugin-svelte": ["prettier-plugin-svelte@2.10.1", "", { "peerDependencies": { "prettier": "^1.16.4 || ^2.0.0", "svelte": "^3.2.0 || ^4.0.0-next.0" } }, "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ=="],
 
     "vite/rollup": ["rollup@3.30.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA=="],
 

--- a/e2e/fixtures/BasicFixture.svelte
+++ b/e2e/fixtures/BasicFixture.svelte
@@ -9,7 +9,10 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
 </header>
 
-<IntersectionObserver {element} bind:intersecting>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 

--- a/e2e/fixtures/ElementChangeFixture.svelte
+++ b/e2e/fixtures/ElementChangeFixture.svelte
@@ -8,16 +8,32 @@
 
 <header class:intersecting>
   {intersecting ? "Element is in view" : "Element is not in view"}
-  <button data-testid="switch" on:click={() => (element = elementB)}>
+  <button
+    data-testid="switch"
+    on:click={() => (element = elementB)}
+  >
     Switch
   </button>
 </header>
 
-<IntersectionObserver {element} bind:intersecting>
-  <div data-testid="element-a" bind:this={element}>A</div>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+>
+  <div
+    data-testid="element-a"
+    bind:this={element}
+  >
+    A
+  </div>
 </IntersectionObserver>
 
-<div data-testid="element-b" bind:this={elementB}>B</div>
+<div
+  data-testid="element-b"
+  bind:this={elementB}
+>
+  B
+</div>
 
 <style>
   header {

--- a/e2e/fixtures/MultipleBasicFixture.svelte
+++ b/e2e/fixtures/MultipleBasicFixture.svelte
@@ -7,7 +7,10 @@
   $: elements = [ref1, ref2];
 </script>
 
-<MultipleIntersectionObserver {elements} let:elementIntersections>
+<MultipleIntersectionObserver
+  {elements}
+  let:elementIntersections
+>
   <header>
     <div
       data-testid="item-1-indicator"
@@ -23,8 +26,18 @@
     </div>
   </header>
 
-  <div bind:this={ref1} data-testid="item-1">Item 1</div>
-  <div bind:this={ref2} data-testid="item-2">Item 2</div>
+  <div
+    bind:this={ref1}
+    data-testid="item-1"
+  >
+    Item 1
+  </div>
+  <div
+    bind:this={ref2}
+    data-testid="item-2"
+  >
+    Item 2
+  </div>
 </MultipleIntersectionObserver>
 
 <style>

--- a/e2e/fixtures/MultipleBindingFixture.svelte
+++ b/e2e/fixtures/MultipleBindingFixture.svelte
@@ -6,9 +6,7 @@
   let elementIntersections = new Map<HTMLElement | null, boolean>();
 
   $: elements = [ref1, ref2];
-  $: anyItemVisible = Array.from(elementIntersections.values()).some(
-    (visible) => visible,
-  );
+  $: anyItemVisible = Array.from(elementIntersections.values()).some((visible) => visible);
 </script>
 
 <MultipleIntersectionObserver
@@ -29,9 +27,7 @@
     {#each elements as element, index}
       {@const visible = elementIntersections.get(element)}
       {#if visible}
-        <p data-testid="item-{index + 1}-status">
-          Item {index + 1} is visible
-        </p>
+        <p data-testid="item-{index + 1}-status">Item {index + 1} is visible</p>
       {/if}
     {/each}
   </header>

--- a/e2e/fixtures/MultipleElementsChangeFixture.svelte
+++ b/e2e/fixtures/MultipleElementsChangeFixture.svelte
@@ -9,9 +9,15 @@
   $: elements = [includeItem1 ? ref1 : null, includeItem2 ? ref2 : null];
 </script>
 
-<MultipleIntersectionObserver {elements} let:elementIntersections>
+<MultipleIntersectionObserver
+  {elements}
+  let:elementIntersections
+>
   <header>
-    <button data-testid="add-item-2" on:click={() => (includeItem2 = true)}>
+    <button
+      data-testid="add-item-2"
+      on:click={() => (includeItem2 = true)}
+    >
       Add item 2
     </button>
     <button
@@ -20,12 +26,8 @@
     >
       Remove item 1
     </button>
-    <p data-testid="item-1-status">
-      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-2-status">
-      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
-    </p>
+    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
   </header>
 
   <div style="display: flex; margin-top: calc(100vh + 1px);">

--- a/e2e/fixtures/MultipleFixture.svelte
+++ b/e2e/fixtures/MultipleFixture.svelte
@@ -8,23 +8,39 @@
   $: elements = [ref1, ref2, ref3];
 </script>
 
-<MultipleIntersectionObserver {elements} let:elementIntersections>
+<MultipleIntersectionObserver
+  {elements}
+  let:elementIntersections
+>
   <header>
     {#each elements as el, index}
       {@const visible = elementIntersections.get(el)}
       {#if visible}
         <p data-testid="item-{index + 1}-status">Item {index + 1} is visible</p>
       {:else}
-        <p data-testid="item-{index + 1}-status">
-          Item {index + 1} is not visible
-        </p>
+        <p data-testid="item-{index + 1}-status">Item {index + 1} is not visible</p>
       {/if}
     {/each}
   </header>
 
-  <div bind:this={ref1} data-testid="item-1">Item 1</div>
-  <div bind:this={ref2} data-testid="item-2">Item 2</div>
-  <div bind:this={ref3} data-testid="item-3">Item 3</div>
+  <div
+    bind:this={ref1}
+    data-testid="item-1"
+  >
+    Item 1
+  </div>
+  <div
+    bind:this={ref2}
+    data-testid="item-2"
+  >
+    Item 2
+  </div>
+  <div
+    bind:this={ref3}
+    data-testid="item-3"
+  >
+    Item 3
+  </div>
 </MultipleIntersectionObserver>
 
 <style>

--- a/e2e/fixtures/MultipleOnceFixture.svelte
+++ b/e2e/fixtures/MultipleOnceFixture.svelte
@@ -19,18 +19,24 @@
   }}
 >
   <header>
-    <p data-testid="item-1-status">
-      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-2-status">
-      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
-    </p>
+    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
     <p data-testid="item-1-count">Item 1 intersect count: {intersectCount1}</p>
     <p data-testid="item-2-count">Item 2 intersect count: {intersectCount2}</p>
   </header>
 
-  <div bind:this={ref1} data-testid="item-1">Item 1</div>
-  <div bind:this={ref2} data-testid="item-2">Item 2</div>
+  <div
+    bind:this={ref1}
+    data-testid="item-1"
+  >
+    Item 1
+  </div>
+  <div
+    bind:this={ref2}
+    data-testid="item-2"
+  >
+    Item 2
+  </div>
 </MultipleIntersectionObserver>
 
 <style>

--- a/e2e/fixtures/MultipleRootFixture.svelte
+++ b/e2e/fixtures/MultipleRootFixture.svelte
@@ -17,7 +17,11 @@
   data-testid="container"
   style="height: 200px; overflow-y: auto;"
 >
-  <MultipleIntersectionObserver {elements} root={container} bind:elementIntersections>
+  <MultipleIntersectionObserver
+    {elements}
+    root={container}
+    bind:elementIntersections
+  >
     <div
       bind:this={ref1}
       style="margin-top: 400px; height: 100px; background-color: #376462; color: #fff;"

--- a/e2e/fixtures/MultipleRootMarginChangeFixture.svelte
+++ b/e2e/fixtures/MultipleRootMarginChangeFixture.svelte
@@ -7,7 +7,11 @@
   $: elements = [ref1];
 </script>
 
-<MultipleIntersectionObserver {elements} {rootMargin} let:elementIntersections>
+<MultipleIntersectionObserver
+  {elements}
+  {rootMargin}
+  let:elementIntersections
+>
   <header>
     {elementIntersections.get(ref1) ? "Element is in view" : "Element is not in view"}
     <button

--- a/e2e/fixtures/OnceFixture.svelte
+++ b/e2e/fixtures/OnceFixture.svelte
@@ -10,7 +10,10 @@
 <header class:intersecting>
   {intersecting ? "Element is in view" : "Element is not in view"}
   <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
-  <button data-testid="unrelated-button" on:click={() => (unrelated += 1)}>
+  <button
+    data-testid="unrelated-button"
+    on:click={() => (unrelated += 1)}
+  >
     Unrelated: {unrelated}
   </button>
 </header>

--- a/e2e/fixtures/RootFixture.svelte
+++ b/e2e/fixtures/RootFixture.svelte
@@ -15,7 +15,11 @@
   data-testid="container"
   style="height: 200px; overflow-y: auto;"
 >
-  <IntersectionObserver {element} root={container} bind:intersecting>
+  <IntersectionObserver
+    {element}
+    root={container}
+    bind:intersecting
+  >
     <div
       bind:this={element}
       style="margin-top: 400px; height: 100px; background-color: #376462; color: #fff;"

--- a/e2e/fixtures/RootMarginChangeFixture.svelte
+++ b/e2e/fixtures/RootMarginChangeFixture.svelte
@@ -16,7 +16,11 @@
   </button>
 </header>
 
-<IntersectionObserver {element} bind:intersecting {rootMargin}>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  {rootMargin}
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 

--- a/e2e/fixtures/RootMarginFixture.svelte
+++ b/e2e/fixtures/RootMarginFixture.svelte
@@ -10,7 +10,11 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
 </header>
 
-<IntersectionObserver {element} bind:intersecting {rootMargin}>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  {rootMargin}
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 

--- a/e2e/fixtures/ThresholdFixture.svelte
+++ b/e2e/fixtures/ThresholdFixture.svelte
@@ -9,7 +9,11 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
 </header>
 
-<IntersectionObserver {element} bind:intersecting threshold={0.5}>
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  threshold={0.5}
+>
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 

--- a/e2e/fixtures/basic.html
+++ b/e2e/fixtures/basic.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Basic Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./basic.ts"></script>
+    <script
+      type="module"
+      src="./basic.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/element-change.html
+++ b/e2e/fixtures/element-change.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Element Change Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./element-change.ts"></script>
+    <script
+      type="module"
+      src="./element-change.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-basic.html
+++ b/e2e/fixtures/multiple-basic.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Basic Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-basic.ts"></script>
+    <script
+      type="module"
+      src="./multiple-basic.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-binding.html
+++ b/e2e/fixtures/multiple-binding.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Binding Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-binding.ts"></script>
+    <script
+      type="module"
+      src="./multiple-binding.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-elements-change.html
+++ b/e2e/fixtures/multiple-elements-change.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Elements Change Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-elements-change.ts"></script>
+    <script
+      type="module"
+      src="./multiple-elements-change.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-once.html
+++ b/e2e/fixtures/multiple-once.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Once Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-once.ts"></script>
+    <script
+      type="module"
+      src="./multiple-once.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-root-margin-change.html
+++ b/e2e/fixtures/multiple-root-margin-change.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Root Margin Change Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-root-margin-change.ts"></script>
+    <script
+      type="module"
+      src="./multiple-root-margin-change.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-root.html
+++ b/e2e/fixtures/multiple-root.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Root Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-root.ts"></script>
+    <script
+      type="module"
+      src="./multiple-root.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple-threshold.html
+++ b/e2e/fixtures/multiple-threshold.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Threshold Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple-threshold.ts"></script>
+    <script
+      type="module"
+      src="./multiple-threshold.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/multiple.html
+++ b/e2e/fixtures/multiple.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Multiple Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./multiple.ts"></script>
+    <script
+      type="module"
+      src="./multiple.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/once.html
+++ b/e2e/fixtures/once.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Once Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./once.ts"></script>
+    <script
+      type="module"
+      src="./once.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/once.ts
+++ b/e2e/fixtures/once.ts
@@ -1,4 +1,4 @@
-import OnceFixture from "./OnceFixture.svelte";
 import { mount } from "./mount";
+import OnceFixture from "./OnceFixture.svelte";
 
 mount(OnceFixture);

--- a/e2e/fixtures/root-margin-change.html
+++ b/e2e/fixtures/root-margin-change.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Root Margin Change Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./root-margin-change.ts"></script>
+    <script
+      type="module"
+      src="./root-margin-change.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/root-margin-change.ts
+++ b/e2e/fixtures/root-margin-change.ts
@@ -1,4 +1,4 @@
-import RootMarginChangeFixture from "./RootMarginChangeFixture.svelte";
 import { mount } from "./mount";
+import RootMarginChangeFixture from "./RootMarginChangeFixture.svelte";
 
 mount(RootMarginChangeFixture);

--- a/e2e/fixtures/root-margin.html
+++ b/e2e/fixtures/root-margin.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Root Margin Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./root-margin.ts"></script>
+    <script
+      type="module"
+      src="./root-margin.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/root-margin.ts
+++ b/e2e/fixtures/root-margin.ts
@@ -1,4 +1,4 @@
-import RootMarginFixture from "./RootMarginFixture.svelte";
 import { mount } from "./mount";
+import RootMarginFixture from "./RootMarginFixture.svelte";
 
 mount(RootMarginFixture);

--- a/e2e/fixtures/root.html
+++ b/e2e/fixtures/root.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Root Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./root.ts"></script>
+    <script
+      type="module"
+      src="./root.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/root.ts
+++ b/e2e/fixtures/root.ts
@@ -1,4 +1,4 @@
-import RootFixture from "./RootFixture.svelte";
 import { mount } from "./mount";
+import RootFixture from "./RootFixture.svelte";
 
 mount(RootFixture);

--- a/e2e/fixtures/threshold.html
+++ b/e2e/fixtures/threshold.html
@@ -1,12 +1,18 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
     <title>Threshold Test</title>
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="./threshold.ts"></script>
+    <script
+      type="module"
+      src="./threshold.ts"
+    ></script>
   </body>
 </html>

--- a/e2e/fixtures/threshold.ts
+++ b/e2e/fixtures/threshold.ts
@@ -1,4 +1,4 @@
-import ThresholdFixture from "./ThresholdFixture.svelte";
 import { mount } from "./mount";
+import ThresholdFixture from "./ThresholdFixture.svelte";
 
 mount(ThresholdFixture);

--- a/e2e/intersection-observer.test.ts
+++ b/e2e/intersection-observer.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.use({ viewport: { width: 1200, height: 600 } });
 
@@ -28,28 +28,20 @@ test("Once", async ({ page }) => {
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Once - does not re-dispatch intersect on unrelated updates", async ({
-  page,
-}) => {
+test("Once - does not re-dispatch intersect on unrelated updates", async ({ page }) => {
   await page.goto("/once.html");
 
-  await expect(page.getByTestId("intersect-count")).toHaveText(
-    /Intersect count: 0/,
-  );
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 0/);
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   await expect(page.locator("header")).toHaveText(/Element is in view/);
-  await expect(page.getByTestId("intersect-count")).toHaveText(
-    /Intersect count: 1/,
-  );
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
 
   await page.getByTestId("unrelated-button").click();
   await page.getByTestId("unrelated-button").click();
   await page.getByTestId("unrelated-button").click();
 
-  await expect(page.getByTestId("intersect-count")).toHaveText(
-    /Intersect count: 1/,
-  );
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
 });
 
 test("Root margin", async ({ page }) => {
@@ -65,9 +57,7 @@ test("Root margin", async ({ page }) => {
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Element - switching the observed element retargets the observer", async ({
-  page,
-}) => {
+test("Element - switching the observed element retargets the observer", async ({ page }) => {
   await page.goto("/element-change.html");
 
   await expect(page.locator("header")).toHaveText(/Element is in view/);
@@ -79,9 +69,7 @@ test("Element - switching the observed element retargets the observer", async ({
   await expect(page.locator("header")).toHaveText(/Element is in view/);
 });
 
-test("Root margin - reinitializes the observer when changed at runtime", async ({
-  page,
-}) => {
+test("Root margin - reinitializes the observer when changed at runtime", async ({ page }) => {
   await page.goto("/root-margin-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 200));
@@ -91,9 +79,7 @@ test("Root margin - reinitializes the observer when changed at runtime", async (
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({
-  page,
-}) => {
+test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({ page }) => {
   await page.goto("/multiple-root-margin-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 200));
@@ -103,15 +89,11 @@ test("Multiple elements - reinitializes the observer when root margin changes at
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Root - uses a custom scroll container instead of the viewport", async ({
-  page,
-}) => {
+test("Root - uses a custom scroll container instead of the viewport", async ({ page }) => {
   await page.goto("/root.html");
   const app = page.locator("#app");
 
-  await expect(page.getByTestId("status")).toHaveText(
-    /Element is not in view/,
-  );
+  await expect(page.getByTestId("status")).toHaveText(/Element is not in view/);
 
   await page.getByTestId("container").evaluate((el) => {
     el.scrollTop = el.scrollHeight;
@@ -121,14 +103,10 @@ test("Root - uses a custom scroll container instead of the viewport", async ({
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Multiple elements - uses a custom scroll container instead of the viewport", async ({
-  page,
-}) => {
+test("Multiple elements - uses a custom scroll container instead of the viewport", async ({ page }) => {
   await page.goto("/multiple-root.html");
 
-  await expect(page.getByTestId("status")).toHaveText(
-    /Element is not in view/,
-  );
+  await expect(page.getByTestId("status")).toHaveText(/Element is not in view/);
 
   await page.getByTestId("container").evaluate((el) => {
     el.scrollTop = el.scrollHeight;
@@ -137,9 +115,7 @@ test("Multiple elements - uses a custom scroll container instead of the viewport
   await expect(page.getByTestId("status")).toHaveText(/Element is in view/);
 });
 
-test("Threshold - requires a minimum visible ratio before intersecting", async ({
-  page,
-}) => {
+test("Threshold - requires a minimum visible ratio before intersecting", async ({ page }) => {
   await page.goto("/threshold.html");
   const app = page.locator("#app");
 
@@ -153,9 +129,7 @@ test("Threshold - requires a minimum visible ratio before intersecting", async (
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Multiple elements - threshold requires a minimum visible ratio", async ({
-  page,
-}) => {
+test("Multiple elements - threshold requires a minimum visible ratio", async ({ page }) => {
   await page.goto("/multiple-threshold.html");
 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
@@ -170,129 +144,67 @@ test("Multiple elements - threshold requires a minimum visible ratio", async ({
 test("Multiple elements", async ({ page }) => {
   await page.goto("/multiple.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-3-status")).toHaveText(
-    /Item 3 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-3-status")).toHaveText(
-    /Item 3 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is visible/,
-  );
-  await expect(page.getByTestId("item-3-status")).toHaveText(
-    /Item 3 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
+  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-3-status")).toHaveText(
-    /Item 3 is visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is visible/);
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-3-status")).toHaveText(
-    /Item 3 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
 });
 
 test("Multiple elements - once", async ({ page }) => {
   await page.goto("/multiple-once.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-1-count")).toHaveText(
-    /Item 1 intersect count: 0/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 0/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
-  await expect(page.getByTestId("item-1-count")).toHaveText(
-    /Item 1 intersect count: 1/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 1/);
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
-  await expect(page.getByTestId("item-1-count")).toHaveText(
-    /Item 1 intersect count: 1/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 1/);
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-count")).toHaveText(
-    /Item 2 intersect count: 0/,
-  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-2-count")).toHaveText(/Item 2 intersect count: 0/);
 });
 
-test("Multiple elements - elements array add/remove retargets the observer", async ({
-  page,
-}) => {
+test("Multiple elements - elements array add/remove retargets the observer", async ({ page }) => {
   await page.goto("/multiple-elements-change.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is not visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
 
   await page.getByTestId("add-item-2").click();
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is visible/,
-  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
 
   await page.getByTestId("remove-item-1").click();
   await page.evaluate(() => window.scrollTo(0, 0));
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is not visible/,
-  );
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
 });
 
 test("Multiple elements - basic pattern", async ({ page }) => {
@@ -305,19 +217,13 @@ test("Multiple elements - basic pattern", async ({ page }) => {
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✓/);
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✗/);
 
-  await expect(page.getByTestId("item-1-indicator")).toHaveClass(
-    /intersecting/,
-  );
-  await expect(page.getByTestId("item-2-indicator")).not.toHaveClass(
-    /intersecting/,
-  );
+  await expect(page.getByTestId("item-1-indicator")).toHaveClass(/intersecting/);
+  await expect(page.getByTestId("item-2-indicator")).not.toHaveClass(/intersecting/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✓/);
-  await expect(page.getByTestId("item-2-indicator")).toHaveClass(
-    /intersecting/,
-  );
+  await expect(page.getByTestId("item-2-indicator")).toHaveClass(/intersecting/);
 
   await page.evaluate(() => window.scrollTo(0, 0));
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
@@ -327,82 +233,37 @@ test("Multiple elements - basic pattern", async ({ page }) => {
 test("Multiple elements - binding pattern", async ({ page }) => {
   await page.goto("/multiple-binding.html");
 
-  await expect(page.getByTestId("header-status")).toHaveText(
-    /No items visible/,
-  );
-  await expect(page.getByTestId("header")).toHaveAttribute(
-    "data-any-visible",
-    "false",
-  );
+  await expect(page.getByTestId("header-status")).toHaveText(/No items visible/);
+  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "false");
   await expect(page.getByTestId("header")).not.toHaveClass(/intersecting/);
 
-  await expect(page.getByTestId("item-1")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
-  await expect(page.getByTestId("item-2")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
+  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
 
-  await expect(page.getByTestId("header-status")).toHaveText(
-    /At least one item is visible/,
-  );
-  await expect(page.getByTestId("header")).toHaveAttribute(
-    "data-any-visible",
-    "true",
-  );
+  await expect(page.getByTestId("header-status")).toHaveText(/At least one item is visible/);
+  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "true");
   await expect(page.getByTestId("header")).toHaveClass(/intersecting/);
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(
-    /Item 1 is visible/,
-  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
 
-  await expect(page.getByTestId("item-1")).toHaveAttribute(
-    "data-visible",
-    "true",
-  );
+  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "true");
   await expect(page.getByTestId("item-1")).toHaveClass(/visible/);
-  await expect(page.getByTestId("item-2")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
+  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
 
-  await expect(page.getByTestId("header-status")).toHaveText(
-    /At least one item is visible/,
-  );
+  await expect(page.getByTestId("header-status")).toHaveText(/At least one item is visible/);
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(
-    /Item 2 is visible/,
-  );
-  await expect(page.getByTestId("item-2")).toHaveAttribute(
-    "data-visible",
-    "true",
-  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
+  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "true");
   await expect(page.getByTestId("item-2")).toHaveClass(/visible/);
-  await expect(page.getByTestId("item-1")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
+  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("header-status")).toHaveText(
-    /No items visible/,
-  );
-  await expect(page.getByTestId("header")).toHaveAttribute(
-    "data-any-visible",
-    "false",
-  );
-  await expect(page.getByTestId("item-1")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
-  await expect(page.getByTestId("item-2")).toHaveAttribute(
-    "data-visible",
-    "false",
-  );
+  await expect(page.getByTestId("header-status")).toHaveText(/No items visible/);
+  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "false");
+  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
 });

--- a/e2e/vite.config.ts
+++ b/e2e/vite.config.ts
@@ -6,9 +6,7 @@ import { defineConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtures = path.resolve(__dirname, "fixtures");
-const pkg = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf-8"),
-);
+const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf-8"));
 
 // Every fixture .html is its own entry point so `vite build` emits the full
 // multi-page app. The dev server discovers these automatically, but the
@@ -17,10 +15,7 @@ const input = Object.fromEntries(
   fs
     .readdirSync(fixtures)
     .filter((file) => file.endsWith(".html"))
-    .map((file) => [
-      file.slice(0, -".html".length),
-      path.resolve(fixtures, file),
-    ]),
+    .map((file) => [file.slice(0, -".html".length), path.resolve(fixtures, file)]),
 );
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "package": "bun scripts/npm-package.ts",
     "test:types": "bun --bun svelte-check --workspace tests --tsgo",
     "test:e2e": "playwright test",
-    "format": "bun --bun prettier --write . --cache"
+    "lint": "biome check --write .",
+    "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched ."
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.2",
     "@playwright/test": "^1.61.1",
     "@sveltejs/vite-plugin-svelte": "^2.5.3",
     "@types/bun": "^1.3.6",
     "@typescript/native-preview": "^7.0.0-dev.20260703.1",
-    "prettier": "^3.8.0",
-    "prettier-plugin-svelte": "^3.4.1",
     "svelte": "3.59.2",
     "svelte-check": "^4.7.1",
     "svelte-readme": "^3.6.3",
@@ -40,10 +40,5 @@
     "viewport",
     "lazy-loading",
     "conditional"
-  ],
-  "prettier": {
-    "plugins": [
-      "prettier-plugin-svelte"
-    ]
-  }
+  ]
 }

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -12,11 +12,7 @@ await Bun.write("./package/LICENSE", Bun.file("./LICENSE"));
 
 await $`cp -r ./src/* ./package/`;
 
-const pkgJson = await pkg.json();
-
-delete pkgJson.scripts;
-delete pkgJson.devDependencies;
-delete pkgJson.prettier;
+const { scripts, devDependencies, ...pkgJson } = await pkg.json();
 
 pkgJson.main = "./index.js";
 pkgJson.types = "./index.d.ts";

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -46,7 +46,7 @@
    */
   export let observer = null;
 
-  import { tick, createEventDispatcher, afterUpdate, onMount } from "svelte";
+  import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -59,7 +59,7 @@
   const initialize = () => {
     observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((_entry) => {
+        for (const _entry of entries) {
           entry = _entry;
           intersecting = _entry.isIntersecting;
 
@@ -70,7 +70,7 @@
 
             if (element && once) observer?.unobserve(element);
           }
-        });
+        }
       },
       { root, rootMargin, threshold },
     );
@@ -107,4 +107,8 @@
   });
 </script>
 
-<slot {intersecting} {entry} {observer} />
+<slot
+  {intersecting}
+  {entry}
+  {observer}
+/>

--- a/src/IntersectionObserver.svelte.d.ts
+++ b/src/IntersectionObserver.svelte.d.ts
@@ -65,9 +65,7 @@ export default class extends SvelteComponentTyped<
      * Dispatched only when the element is intersecting the viewport.
      * `event.detail.isIntersecting` will only be `true`
      */
-    intersect: CustomEvent<
-      IntersectionObserverEntry & { isIntersecting: true }
-    >;
+    intersect: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>;
   },
   {
     default: {

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -54,9 +54,6 @@
   /** @type {null | string} */
   let prevRootMargin = null;
 
-  /** @type {null | HTMLElement} */
-  let prevElement = null;
-
   /** @type {(HTMLElement | null)[]} */
   let prevElements = [];
 
@@ -119,7 +116,6 @@
 
     if (prevRootMargin && rootMargin !== prevRootMargin) {
       observer?.disconnect();
-      prevElement = null;
       prevElements = [];
       initialize();
 

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -47,7 +47,7 @@
    */
   export let observer = null;
 
-  import { tick, createEventDispatcher, afterUpdate, onMount } from "svelte";
+  import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -60,7 +60,7 @@
   const initialize = () => {
     observer = new IntersectionObserver(
       (entries) => {
-        entries.forEach((_entry) => {
+        for (const _entry of entries) {
           const target = /** @type {HTMLElement} */ (_entry.target);
 
           elementIntersections.set(target, _entry.isIntersecting);
@@ -76,7 +76,7 @@
             dispatch("intersect", { entry: _entry, target });
             if (once) observer?.unobserve(target);
           }
-        });
+        }
       },
       { root, rootMargin, threshold },
     );
@@ -97,19 +97,15 @@
     await tick();
 
     if (elements.length > 0) {
-      const newElements = elements.filter(
-        (el) => el && !prevElements.includes(el),
-      );
-      newElements.forEach((el) => {
+      const newElements = elements.filter((el) => el && !prevElements.includes(el));
+      for (const el of newElements) {
         if (el) observer?.observe(el);
-      });
+      }
 
-      const removedElements = prevElements.filter(
-        (el) => el && !elements.includes(el),
-      );
-      removedElements.forEach((el) => {
+      const removedElements = prevElements.filter((el) => el && !elements.includes(el));
+      for (const el of removedElements) {
         if (el) observer?.unobserve(el);
-      });
+      }
 
       prevElements = [...elements];
     }
@@ -119,15 +115,17 @@
       prevElements = [];
       initialize();
 
-      elements
-        .filter((el) => el)
-        .forEach((el) => {
-          if (el) observer?.observe(el);
-        });
+      for (const el of elements.filter((el) => el)) {
+        if (el) observer?.observe(el);
+      }
     }
 
     prevRootMargin = rootMargin;
   });
 </script>
 
-<slot {observer} {elementIntersections} {elementEntries} />
+<slot
+  {observer}
+  {elementIntersections}
+  {elementEntries}
+/>

--- a/tests/IntersectionObserver.test.svelte
+++ b/tests/IntersectionObserver.test.svelte
@@ -3,8 +3,8 @@
    * Run `bun test:types` to test the type definitions of the component using `svelte-check`.
    */
 
-  import SvelteIntersectionObserver from "svelte-intersection-observer";
   import type { ComponentProps } from "svelte";
+  import SvelteIntersectionObserver from "svelte-intersection-observer";
 
   type Props = ComponentProps<SvelteIntersectionObserver>;
 

--- a/tests/MultipleIntersectionObserver.test.svelte
+++ b/tests/MultipleIntersectionObserver.test.svelte
@@ -3,8 +3,8 @@
    * Run `bun test:types` to test the type definitions of the component using `svelte-check`.
    */
 
-  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
   import type { ComponentProps } from "svelte";
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
 
   type Props = ComponentProps<MultipleIntersectionObserver>;
 


### PR DESCRIPTION
- Replace prettier and prettier-plugin-svelte with Biome 2.5.2 for linting and formatting
- Add lint and lint:changed scripts, run biome ci in CI
- Fix lint violations surfaced by the new rules: forEach converted to for...of in the observer components, a dead prevElement variable removed, and delete replaced with rest destructuring in npm-package.ts
