### PR TITLE
feat: add use:intersect action

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,22 +176,22 @@ As an alternative to the `IntersectionObserver` component, use the `intersect` a
 <script>
   import { intersect } from "svelte-intersection-observer";
 
-  let intersecting = false;
+  let actionIntersecting = false;
 </script>
 
-<header class:intersecting>
-  {intersecting ? "Element is in view" : "Element is not in view"}
+<header class:intersecting={actionIntersecting}>
+  {actionIntersecting ? "Element is in view" : "Element is not in view"}
 </header>
 
 <div
   use:intersect={{ once: true }}
-  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+  on:observe={(e) => (actionIntersecting = e.detail.isIntersecting)}
 >
   Hello world
 </div>
 ```
 
-Options passed to `use:intersect={{ ... }}` are reactive — updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer.
+Options passed to `use:intersect` are reactive — updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer.
 
 ### Multiple elements
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,31 @@ To detect when a user has scrolled to the end of a scrollable container, place a
 </div>
 ```
 
+### `use:intersect` action
+
+As an alternative to the `IntersectionObserver` component, use the `intersect` action to observe an element directly with `use:`, without a `bind:this` reference or wrapper markup. Listen for `on:observe`/`on:intersect` on the observed element itself.
+
+```svelte
+<script>
+  import { intersect } from "svelte-intersection-observer";
+
+  let intersecting = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+</header>
+
+<div
+  use:intersect={{ once: true }}
+  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+```
+
+Options passed to `use:intersect={{ ... }}` are reactive — updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer.
+
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements.
@@ -312,6 +337,24 @@ The `e.detail` for both events includes:
 | observer             | [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)                                         |
 | elementIntersections | `Map<HTMLElement \| null, boolean>`                                                                                                     |
 | elementEntries       | `Map<HTMLElement \| null,` [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)`>` |
+
+### `intersect` action
+
+#### Options
+
+| Name       | Description                                                  | Type                                                                | Default value |
+| :--------- | :------------------------------------------------------------ | :------------------------------------------------------------------- | :------------- |
+| root       | Containing element                                            | `null` or `HTMLElement`                                             | `null`         |
+| rootMargin | Margin offset of the containing element                       | `string`                                                            | `"0px"`        |
+| threshold  | Percentage of element visibility to trigger an event          | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`            |
+| once       | Unobserve the element after the first intersection event      | `boolean`                                                           | `false`        |
+
+#### Dispatched events
+
+- **on:observe**: fired on the element when it is first observed or whenever an intersection change occurs
+- **on:intersect**: fired on the element when it is intersecting the viewport
+
+The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
 
 ### `IntersectionObserverEntry` interface
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,4 @@
 export { default } from "./IntersectionObserver.svelte";
+export type { IntersectActionOptions } from "./intersect.js";
+export { intersect } from "./intersect.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default } from "./IntersectionObserver.svelte";
+export { intersect } from "./intersect.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/intersect.d.ts
+++ b/src/intersect.d.ts
@@ -1,0 +1,44 @@
+import type { Action } from "svelte/action";
+
+export interface IntersectActionOptions {
+  /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
+   * @default null
+   */
+  root?: null | HTMLElement;
+
+  /**
+   * Margin offset of the containing element.
+   * @default "0px"
+   */
+  rootMargin?: string;
+
+  /**
+   * Percentage of element visibility to trigger an event.
+   * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
+   * @default 0
+   */
+  threshold?: number | number[];
+
+  /**
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
+   * @default false
+   */
+  once?: boolean;
+}
+
+/**
+ * Svelte action that observes the element with the Intersection Observer API.
+ * Dispatches `observe` (on every change) and `intersect` (on entering the
+ * viewport) `CustomEvent`s on the element — listen with `on:observe`/`on:intersect`.
+ */
+export const intersect: Action<
+  HTMLElement,
+  IntersectActionOptions | undefined,
+  {
+    "on:observe"?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+    "on:intersect"?: (event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>) => void;
+  }
+>;

--- a/src/intersect.js
+++ b/src/intersect.js
@@ -1,0 +1,56 @@
+/**
+ * Svelte action that observes `node` with the Intersection Observer API.
+ * Dispatches `observe` (on every change) and `intersect` (on entering the
+ * viewport) `CustomEvent`s on `node` — listen with `on:observe`/`on:intersect`.
+ * @param {HTMLElement} node
+ * @param {import("./intersect.d.ts").IntersectActionOptions} [options]
+ */
+export function intersect(node, options = {}) {
+  let { root = null, rootMargin = "0px", threshold = 0, once = false } = options;
+
+  /** @type {IntersectionObserver} */
+  let observer;
+
+  const createObserver = () =>
+    new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          node.dispatchEvent(new CustomEvent("observe", { detail: entry }));
+
+          if (entry.isIntersecting) {
+            node.dispatchEvent(new CustomEvent("intersect", { detail: entry }));
+            if (once) observer.unobserve(node);
+          }
+        }
+      },
+      { root, rootMargin, threshold },
+    );
+
+  observer = createObserver();
+  observer.observe(node);
+
+  return {
+    /** @param {import("./intersect.d.ts").IntersectActionOptions} [newOptions] */
+    update(newOptions = {}) {
+      once = newOptions.once ?? false;
+
+      const configChanged =
+        (newOptions.root ?? null) !== root ||
+        (newOptions.rootMargin ?? "0px") !== rootMargin ||
+        JSON.stringify(newOptions.threshold ?? 0) !== JSON.stringify(threshold);
+
+      if (configChanged) {
+        root = newOptions.root ?? null;
+        rootMargin = newOptions.rootMargin ?? "0px";
+        threshold = newOptions.threshold ?? 0;
+
+        observer.disconnect();
+        observer = createObserver();
+        observer.observe(node);
+      }
+    },
+    destroy() {
+      observer.disconnect();
+    },
+  };
+}

--- a/tests/e2e/fixtures/ActionFixture.svelte
+++ b/tests/e2e/fixtures/ActionFixture.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { intersect } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let intersectCount = 0;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
+</header>
+
+<div
+  use:intersect={{ once: true }}
+  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+  on:intersect={() => (intersectCount += 1)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/ActionRootMarginChangeFixture.svelte
+++ b/tests/e2e/fixtures/ActionRootMarginChangeFixture.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { intersect } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let rootMargin = "0px";
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="shrink-root-margin"
+    on:click={() => (rootMargin = "-200px")}
+  >
+    Shrink root margin
+  </button>
+</header>
+
+<div
+  use:intersect={{ rootMargin }}
+  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/action-root-margin-change.html
+++ b/tests/e2e/fixtures/action-root-margin-change.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Action Root Margin Change Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./action-root-margin-change.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/action-root-margin-change.ts
+++ b/tests/e2e/fixtures/action-root-margin-change.ts
@@ -1,0 +1,4 @@
+import ActionRootMarginChangeFixture from "./ActionRootMarginChangeFixture.svelte";
+import { mount } from "./mount";
+
+mount(ActionRootMarginChangeFixture);

--- a/tests/e2e/fixtures/action.html
+++ b/tests/e2e/fixtures/action.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Action Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./action.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/action.ts
+++ b/tests/e2e/fixtures/action.ts
@@ -1,0 +1,4 @@
+import ActionFixture from "./ActionFixture.svelte";
+import { mount } from "./mount";
+
+mount(ActionFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -79,6 +79,34 @@ test("Root margin - reinitializes the observer when changed at runtime", async (
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Action - use:intersect dispatches observe/intersect events and honors once", async ({ page }) => {
+  await page.goto("/action.html");
+  const app = page.locator("#app");
+
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 0/);
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+  await expect(app).toHaveText(/Hello world/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+});
+
+test("Action - reinitializes the observer when the parameter changes at runtime", async ({ page }) => {
+  await page.goto("/action-root-margin-change.html");
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("shrink-root-margin").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
 test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({ page }) => {
   await page.goto("/multiple-root-margin-change.html");
 

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  /**
+   * Run `bun test:types` to test the type definitions of the action using `svelte-check`.
+   */
+
+  import { type IntersectActionOptions, intersect } from "svelte-intersection-observer";
+
+  let options: IntersectActionOptions = { once: true, rootMargin: "0px", threshold: 0 };
+</script>
+
+<div
+  use:intersect={options}
+  on:observe={(e) => {
+    e.detail.intersectionRect; // DOMRectReadOnly
+    e.detail.isIntersecting; // boolean
+  }}
+  on:intersect={(e) => {
+    e.detail.isIntersecting; // true
+  }}
+>
+  Hello world
+</div>


### PR DESCRIPTION
Adds an action-based alternative to the `IntersectionObserver` component so consumers can attach observation directly to a node with `use:` instead of wiring up `bind:this`.

```svelte
<script>
  import { intersect } from "svelte-intersection-observer";
  let intersecting = false;
</script>

<div
  use:intersect={{ once: true }}
  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
>
  Hello world
</div>
```

Options (`root`, `rootMargin`, `threshold`, `once`) are reactive; the action's `update()` re-initializes the underlying observer when they change, mirroring the reconfigure logic already used by the components. Events (`observe`, `intersect`) dispatch as `CustomEvent`s on the observed node itself.

Includes e2e fixtures/tests covering event dispatch, `once`, and runtime option changes, plus a type-check fixture confirming `on:observe`/`on:intersect` are typed via the action's `Attributes` generic. README updated with usage and API docs.