### PR TITLE
test: cover each-block bind:this + bind:intersecting per item

### DIFF
--- a/tests/e2e/fixtures/EachBindingFixture.svelte
+++ b/tests/e2e/fixtures/EachBindingFixture.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  const sections = [
+    { id: "one", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
+    { id: "two", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
+    { id: "three", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
+  ];
+</script>
+
+{#each sections as { id, node, intersecting }}
+  <IntersectionObserver
+    element={node}
+    bind:intersecting
+  >
+    <section
+      data-testid="section-{id}"
+      class:intersecting
+      bind:this={node}
+    >
+      Section {id}: {intersecting ? "visible" : "not visible"}
+    </section>
+  </IntersectionObserver>
+{/each}
+
+<style>
+  section {
+    height: 50vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+    margin-bottom: 100vh;
+  }
+
+  section:first-of-type {
+    margin-top: calc(100vh + 1px);
+  }
+
+  section.intersecting {
+    background-color: #2ecc71;
+  }
+</style>

--- a/tests/e2e/fixtures/each-binding.html
+++ b/tests/e2e/fixtures/each-binding.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Each Binding Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./each-binding.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/each-binding.ts
+++ b/tests/e2e/fixtures/each-binding.ts
@@ -1,0 +1,4 @@
+import EachBindingFixture from "./EachBindingFixture.svelte";
+import { mount } from "./mount";
+
+mount(EachBindingFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -230,6 +230,31 @@ test("Multiple elements - basic pattern", async ({ page }) => {
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✗/);
 });
 
+test("Each block - bind:this + bind:intersecting per item does not deadlock and tracks independently", async ({
+  page,
+}) => {
+  await page.goto("/each-binding.html", { timeout: 5_000 });
+
+  await expect(page.getByTestId("section-one")).toHaveText(/not visible/);
+  await expect(page.getByTestId("section-two")).toHaveText(/not visible/);
+  await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
+
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
+  await expect(page.getByTestId("section-one")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-two")).toHaveText(/not visible/);
+  await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
+
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2.5 + 50));
+  await expect(page.getByTestId("section-two")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-one")).toHaveText(/not visible/);
+  await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("section-three")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-one")).toHaveText(/not visible/);
+  await expect(page.getByTestId("section-two")).toHaveText(/not visible/);
+});
+
 test("Multiple elements - binding pattern", async ({ page }) => {
   await page.goto("/multiple-binding.html");
 


### PR DESCRIPTION
Investigated issue #69 (reported infinite loop / deadlock when using `IntersectionObserver` inside an `{#each}` block with `bind:this` and `bind:intersecting`). Could not reproduce a library bug: with one `IntersectionObserver` per item and proper per-item state, tracking works correctly with no deadlock. This matches the outcome on the original issue thread, where the reported failure traced back to sharing a single `node`/`intersecting` variable across all loop iterations instead of giving each item its own state.

Adding this as a regression test since it fills a real coverage gap. No existing fixture renders a separate `IntersectionObserver` per `{#each}` item; the other `{#each}` usages only iterate over refs for display and rely on `MultipleIntersectionObserver`'s shared observer instead.

Usage the test verifies:

```svelte
{#each sections as { id, node, intersecting }}
  <IntersectionObserver element={node} bind:intersecting>
    <section bind:this={node}>{id}</section>
  </IntersectionObserver>
{/each}
```

## Test plan
- [x] `bunx playwright test -g "Each block" --project=chromium` passes