### PR TITLE
perf(multiple-intersection-observer): batch Map reassignment per callback

### DIFF
--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -66,10 +66,6 @@
           elementIntersections.set(target, _entry.isIntersecting);
           elementEntries.set(target, _entry);
 
-          // Trigger reactivity.
-          elementIntersections = new Map(elementIntersections);
-          elementEntries = new Map(elementEntries);
-
           dispatch("observe", { entry: _entry, target });
 
           if (_entry.isIntersecting) {
@@ -77,6 +73,10 @@
             if (once) observer?.unobserve(target);
           }
         }
+
+        // Trigger reactivity once per batch, not once per entry.
+        elementIntersections = new Map(elementIntersections);
+        elementEntries = new Map(elementEntries);
       },
       { root, rootMargin, threshold },
     );


### PR DESCRIPTION
## Summary
elementIntersections/elementEntries were reassigned inside the per-entry loop of the observer callback, so N simultaneously-intersecting elements triggered N Svelte re-renders instead of one. This moves the reassignment after the loop.

```js
for (const _entry of entries) {
  elementIntersections.set(target, _entry.isIntersecting);
  elementEntries.set(target, _entry);
  // dispatch events...
}

// Trigger reactivity once per batch, not once per entry.
elementIntersections = new Map(elementIntersections);
elementEntries = new Map(elementEntries);
```

No API changes. Behavior verified against existing "Multiple elements" e2e coverage.

## Test plan
- [x] `bunx playwright test --project=chromium -g "Multiple"` (8 passed)
- [x] `bunx biome check --write src/MultipleIntersectionObserver.svelte`