### PR TITLE
fix: reinitialize observer on threshold/root change at runtime

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -50,8 +50,12 @@
 
   const dispatch = createEventDispatcher();
 
-  /** @type {null | string} */
-  let prevRootMargin = null;
+  let prevRootMargin = rootMargin;
+
+  let prevThreshold = threshold;
+
+  /** @type {null | HTMLElement} */
+  let prevRoot = root;
 
   /** @type {null | HTMLElement} */
   let prevElement = null;
@@ -97,13 +101,15 @@
       prevElement = element;
     }
 
-    if (prevRootMargin && rootMargin !== prevRootMargin) {
+    if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
       observer?.disconnect();
       prevElement = null;
       initialize();
     }
 
     prevRootMargin = rootMargin;
+    prevThreshold = threshold;
+    prevRoot = root;
   });
 </script>
 

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -51,8 +51,12 @@
 
   const dispatch = createEventDispatcher();
 
-  /** @type {null | string} */
-  let prevRootMargin = null;
+  let prevRootMargin = rootMargin;
+
+  let prevThreshold = threshold;
+
+  /** @type {null | HTMLElement} */
+  let prevRoot = root;
 
   /** @type {(HTMLElement | null)[]} */
   let prevElements = [];
@@ -110,7 +114,7 @@
       prevElements = [...elements];
     }
 
-    if (prevRootMargin && rootMargin !== prevRootMargin) {
+    if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
       observer?.disconnect();
       prevElements = [];
       initialize();
@@ -121,6 +125,8 @@
     }
 
     prevRootMargin = rootMargin;
+    prevThreshold = threshold;
+    prevRoot = root;
   });
 </script>
 

--- a/tests/e2e/fixtures/ThresholdChangeFixture.svelte
+++ b/tests/e2e/fixtures/ThresholdChangeFixture.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+  let threshold = 0;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="raise-threshold"
+    on:click={() => (threshold = 0.99)}
+  >
+    Raise threshold
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  {threshold}
+>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: 100vh;
+    height: 100vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/threshold-change.html
+++ b/tests/e2e/fixtures/threshold-change.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Threshold Change Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./threshold-change.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/threshold-change.ts
+++ b/tests/e2e/fixtures/threshold-change.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import ThresholdChangeFixture from "./ThresholdChangeFixture.svelte";
+
+mount(ThresholdChangeFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -79,6 +79,16 @@ test("Root margin - reinitializes the observer when changed at runtime", async (
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Threshold - reinitializes the observer when changed at runtime", async ({ page }) => {
+  await page.goto("/threshold-change.html");
+
+  await page.evaluate(() => window.scrollTo(0, 300));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("raise-threshold").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
 test("Action - use:intersect dispatches observe/intersect events and honors once", async ({ page }) => {
   await page.goto("/action.html");
   const app = page.locator("#app");


### PR DESCRIPTION
## Summary

`afterUpdate` in both components only reinitialized the underlying `IntersectionObserver` when `rootMargin` changed at runtime. Changes to `threshold` or `root` were silently ignored:

```js
if (prevRootMargin && rootMargin !== prevRootMargin) {
  observer?.disconnect();
  prevElement = null;
  initialize();
}
```

Now all three options are tracked and compared:

```js
if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
  observer?.disconnect();
  prevElement = null;
  initialize();
}
```

Related to the `threshold` reactivity issue reported in #37.
