### PR TITLE
fix(perf): add import fallback to root package export

### DIFF
--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -20,6 +20,7 @@ pkgJson.exports = {
   ".": {
     types: "./index.d.ts",
     svelte: "./index.js",
+    import: "./index.js",
   },
   "./*.svelte": {
     types: "./*.svelte.d.ts",


### PR DESCRIPTION
The root `.` export only declared `types` and `svelte` conditions. Resolvers that don't register the custom `svelte` condition (plain Node, Jest without a svelte transform, esbuild/webpack without the svelte resolve plugin, `import.meta.resolve`) fail to resolve the package at all.

```json
".": {
  "types": "./index.d.ts",
  "svelte": "./index.js",
  "import": "./index.js"
}
```

`import` is added after `svelte` so svelte-aware bundlers still resolve to the raw `.svelte` entry point first.
