### PR TITLE
Add `skip` prop to pause observing without losing state

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ The `e.detail` dispatched by the `observe` and `intersect` events is an [`Inters
 | elementIntersections | Map of each element to its intersection state         | `Map<HTMLElement \| null, boolean>`                                                                                                     | `new Map()`   |
 | elementEntries       | Map of each element to its latest entry               | `Map<HTMLElement \| null,` [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)`>` | `new Map()`   |
 | observer             | `IntersectionObserver` instance                       | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)                               | `null`        |
+| skip                 | Pause observing all elements without losing state     | `boolean`                                                                                                                               | `false`       |
 
 #### Dispatched events
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ As an alternative to the `IntersectionObserver` component, use the `intersect` a
 </div>
 ```
 
-Options passed to `use:intersect` are reactive — updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer.
+Options passed to `use:intersect` are reactive — updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer. Updating `skip` toggles observing on the existing observer without re-initializing it.
 
 ### Multiple elements
 
@@ -348,6 +348,7 @@ The `e.detail` for both events includes:
 | rootMargin | Margin offset of the containing element                       | `string`                                                            | `"0px"`        |
 | threshold  | Percentage of element visibility to trigger an event          | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`            |
 | once       | Unobserve the element after the first intersection event      | `boolean`                                                           | `false`        |
+| skip       | Pause observing without disconnecting the observer            | `boolean`                                                           | `false`        |
 
 #### Dispatched events
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ Set `once` to `true` for the intersection event to occur only once. The `element
 </IntersectionObserver>
 ```
 
+### Pausing with `skip`
+
+Set `skip` to `true` to unobserve without disconnecting the underlying observer or losing `entry`/`intersecting` state — useful for pausing tracking on an off-screen carousel panel or a closed modal. Set `skip` back to `false` to resume; unlike `once`, this can be toggled back and forth. `MultipleIntersectionObserver` and the `intersect` action support the same `skip` option.
+
+```svelte
+<script>
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element;
+  let paused = false;
+</script>
+
+<button on:click={() => (paused = !paused)}>
+  {paused ? "Resume" : "Pause"}
+</button>
+
+<IntersectionObserver {element} skip={paused} let:intersecting>
+  <div bind:this={element}>{intersecting ? "In view" : "Not in view"}</div>
+</IntersectionObserver>
+```
+
 ### `let:intersecting`
 
 An alternative to binding to the `intersecting` prop is to use the `let:` directive.
@@ -283,6 +304,7 @@ This avoids instantiating a new observer for every element.
 | threshold    | Percentage of element visibility to trigger an event        | `number` between 0 and 1, or an array of `number`s between 0 and 1                                                  | `0`           |
 | entry        | Observed element metadata                                   | `null` or [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | `null`        |
 | observer     | `IntersectionObserver` instance                             | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)           | `null`        |
+| skip         | Pause observing without losing `entry`/`intersecting` state | `boolean`                                                                                                           | `false`       |
 
 **Note**: the observed `element` must render with a non-zero width and height for `threshold` values greater than `0` to have any effect — this is a constraint of the underlying [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API), not something this component controls.
 

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -46,6 +46,14 @@
    */
   export let observer = null;
 
+  /**
+   * Set to `true` to pause observing without disconnecting the
+   * observer or losing `entry`/`intersecting` state. Set back to
+   * `false` to resume.
+   * @type {boolean}
+   */
+  export let skip = false;
+
   import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher();
@@ -59,6 +67,8 @@
 
   /** @type {null | HTMLElement} */
   let prevElement = null;
+
+  let prevSkip = skip;
 
   const initialize = () => {
     observer = new IntersectionObserver(
@@ -95,10 +105,15 @@
     await tick();
 
     if (element !== null && element !== prevElement) {
-      observer?.observe(element);
+      if (!skip) observer?.observe(element);
 
       if (prevElement !== null) observer?.unobserve(prevElement);
       prevElement = element;
+    }
+
+    if (skip !== prevSkip && element !== null) {
+      if (skip) observer?.unobserve(element);
+      else observer?.observe(element);
     }
 
     if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
@@ -110,6 +125,7 @@
     prevRootMargin = rootMargin;
     prevThreshold = threshold;
     prevRoot = root;
+    prevSkip = skip;
   });
 </script>
 

--- a/src/IntersectionObserver.svelte.d.ts
+++ b/src/IntersectionObserver.svelte.d.ts
@@ -53,6 +53,14 @@ export default class extends SvelteComponentTyped<
      * @default null
      */
     observer?: null | IntersectionObserver;
+
+    /**
+     * Set to `true` to pause observing without disconnecting the
+     * observer or losing `entry`/`intersecting` state. Set back to
+     * `false` to resume.
+     * @default false
+     */
+    skip?: boolean;
   },
   {
     /**

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -47,6 +47,14 @@
    */
   export let observer = null;
 
+  /**
+   * Set to `true` to pause observing all elements without disconnecting
+   * the observer or losing `elementIntersections`/`elementEntries` state.
+   * Set back to `false` to resume.
+   * @type {boolean}
+   */
+  export let skip = false;
+
   import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher();
@@ -60,6 +68,8 @@
 
   /** @type {(HTMLElement | null)[]} */
   let prevElements = [];
+
+  let prevSkip = skip;
 
   const initialize = () => {
     observer = new IntersectionObserver(
@@ -102,8 +112,10 @@
 
     if (elements.length > 0) {
       const newElements = elements.filter((el) => el && !prevElements.includes(el));
-      for (const el of newElements) {
-        if (el) observer?.observe(el);
+      if (!skip) {
+        for (const el of newElements) {
+          if (el) observer?.observe(el);
+        }
       }
 
       const removedElements = prevElements.filter((el) => el && !elements.includes(el));
@@ -114,19 +126,30 @@
       prevElements = [...elements];
     }
 
+    if (skip !== prevSkip) {
+      for (const el of elements.filter((el) => el)) {
+        if (!el) continue;
+        if (skip) observer?.unobserve(el);
+        else observer?.observe(el);
+      }
+    }
+
     if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
       observer?.disconnect();
       prevElements = [];
       initialize();
 
-      for (const el of elements.filter((el) => el)) {
-        if (el) observer?.observe(el);
+      if (!skip) {
+        for (const el of elements.filter((el) => el)) {
+          if (el) observer?.observe(el);
+        }
       }
     }
 
     prevRootMargin = rootMargin;
     prevThreshold = threshold;
     prevRoot = root;
+    prevSkip = skip;
   });
 </script>
 

--- a/src/MultipleIntersectionObserver.svelte.d.ts
+++ b/src/MultipleIntersectionObserver.svelte.d.ts
@@ -53,6 +53,14 @@ export default class extends SvelteComponentTyped<
      * @default null
      */
     observer?: null | IntersectionObserver;
+
+    /**
+     * Set to `true` to pause observing all elements without disconnecting
+     * the observer or losing `elementIntersections`/`elementEntries` state.
+     * Set back to `false` to resume.
+     * @default false
+     */
+    skip?: boolean;
   },
   {
     /**

--- a/src/intersect.d.ts
+++ b/src/intersect.d.ts
@@ -27,6 +27,13 @@ export interface IntersectActionOptions {
    * @default false
    */
   once?: boolean;
+
+  /**
+   * Set to `true` to pause observing without disconnecting the
+   * observer. Set back to `false` to resume.
+   * @default false
+   */
+  skip?: boolean;
 }
 
 /**

--- a/src/intersect.js
+++ b/src/intersect.js
@@ -6,7 +6,7 @@
  * @param {import("./intersect.d.ts").IntersectActionOptions} [options]
  */
 export function intersect(node, options = {}) {
-  let { root = null, rootMargin = "0px", threshold = 0, once = false } = options;
+  let { root = null, rootMargin = "0px", threshold = 0, once = false, skip = false } = options;
 
   /** @type {IntersectionObserver} */
   let observer;
@@ -27,12 +27,14 @@ export function intersect(node, options = {}) {
     );
 
   observer = createObserver();
-  observer.observe(node);
+  if (!skip) observer.observe(node);
 
   return {
     /** @param {import("./intersect.d.ts").IntersectActionOptions} [newOptions] */
     update(newOptions = {}) {
       once = newOptions.once ?? false;
+
+      const newSkip = newOptions.skip ?? false;
 
       const configChanged =
         (newOptions.root ?? null) !== root ||
@@ -46,8 +48,13 @@ export function intersect(node, options = {}) {
 
         observer.disconnect();
         observer = createObserver();
-        observer.observe(node);
+        if (!newSkip) observer.observe(node);
+      } else if (newSkip !== skip) {
+        if (newSkip) observer.unobserve(node);
+        else observer.observe(node);
       }
+
+      skip = newSkip;
     },
     destroy() {
       observer.disconnect();

--- a/tests/IntersectionObserver.test.svelte
+++ b/tests/IntersectionObserver.test.svelte
@@ -12,12 +12,14 @@
   let entry: Props["entry"];
   let element: Props["element"];
   let observer: Props["observer"];
+  let skip: Props["skip"] = false;
 
   $: entry?.isIntersecting;
 </script>
 
 <SvelteIntersectionObserver
   {element}
+  {skip}
   bind:observer
   bind:intersecting
   on:observe={(e) => {

--- a/tests/MultipleIntersectionObserver.test.svelte
+++ b/tests/MultipleIntersectionObserver.test.svelte
@@ -12,6 +12,7 @@
   let elementIntersections: Props["elementIntersections"] = new Map();
   let elementEntries: Props["elementEntries"] = new Map();
   let observer: Props["observer"];
+  let skip: Props["skip"] = false;
 
   let ref1: null | HTMLDivElement = null;
   let ref2: null | HTMLDivElement = null;
@@ -21,6 +22,7 @@
 
 <MultipleIntersectionObserver
   {elements}
+  {skip}
   bind:observer
   bind:elementIntersections
   bind:elementEntries

--- a/tests/e2e/fixtures/ActionSkipFixture.svelte
+++ b/tests/e2e/fixtures/ActionSkipFixture.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { intersect } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let skip = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="toggle-skip"
+    on:click={() => (skip = !skip)}
+  >
+    {skip ? "Resume" : "Pause"}
+  </button>
+</header>
+
+<div
+  use:intersect={{ skip }}
+  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/MultipleSkipFixture.svelte
+++ b/tests/e2e/fixtures/MultipleSkipFixture.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let ref1: null | HTMLDivElement = null;
+  let ref2: null | HTMLDivElement = null;
+  let skip = false;
+
+  $: elements = [ref1, ref2];
+</script>
+
+<MultipleIntersectionObserver
+  {elements}
+  {skip}
+  let:elementIntersections
+>
+  <header>
+    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
+    <button
+      data-testid="toggle-skip"
+      on:click={() => (skip = !skip)}
+    >
+      {skip ? "Resume" : "Pause"}
+    </button>
+  </header>
+
+  <div
+    bind:this={ref1}
+    data-testid="item-1"
+  >
+    Item 1
+  </div>
+  <div
+    bind:this={ref2}
+    data-testid="item-2"
+  >
+    Item 2
+  </div>
+</MultipleIntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    height: 50vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+    margin-bottom: 100vh;
+  }
+
+  div:first-of-type {
+    margin-top: calc(100vh + 1px);
+  }
+</style>

--- a/tests/e2e/fixtures/SkipFixture.svelte
+++ b/tests/e2e/fixtures/SkipFixture.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+  let skip = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="toggle-skip"
+    on:click={() => (skip = !skip)}
+  >
+    {skip ? "Resume" : "Pause"}
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  {skip}
+>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/action-skip.html
+++ b/tests/e2e/fixtures/action-skip.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Action Skip Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./action-skip.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/action-skip.ts
+++ b/tests/e2e/fixtures/action-skip.ts
@@ -1,0 +1,4 @@
+import ActionSkipFixture from "./ActionSkipFixture.svelte";
+import { mount } from "./mount";
+
+mount(ActionSkipFixture);

--- a/tests/e2e/fixtures/multiple-skip.html
+++ b/tests/e2e/fixtures/multiple-skip.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Multiple Skip Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./multiple-skip.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/multiple-skip.ts
+++ b/tests/e2e/fixtures/multiple-skip.ts
@@ -1,0 +1,4 @@
+import MultipleSkipFixture from "./MultipleSkipFixture.svelte";
+import { mount } from "./mount";
+
+mount(MultipleSkipFixture);

--- a/tests/e2e/fixtures/skip.html
+++ b/tests/e2e/fixtures/skip.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Skip Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./skip.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/skip.ts
+++ b/tests/e2e/fixtures/skip.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import SkipFixture from "./SkipFixture.svelte";
+
+mount(SkipFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -89,6 +89,22 @@ test("Threshold - reinitializes the observer when changed at runtime", async ({ 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Skip - pauses observing without losing state, resumes on toggle", async ({ page }) => {
+  await page.goto("/skip.html");
+  const header = page.locator("header");
+
+  await expect(header).toHaveText(/Element is not in view/);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await expect(header).toHaveText(/Element is not in view/);
+});
+
 test("Action - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
   await page.goto("/action-skip.html");
   const header = page.locator("header");

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -105,6 +105,21 @@ test("Skip - pauses observing without losing state, resumes on toggle", async ({
   await expect(header).toHaveText(/Element is not in view/);
 });
 
+test("Multiple elements - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
+  await page.goto("/multiple-skip.html");
+
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+
+  await page.getByTestId("toggle-skip").click();
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+
+  await page.getByTestId("toggle-skip").click();
+  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+});
+
 test("Action - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
   await page.goto("/action-skip.html");
   const header = page.locator("header");

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -89,6 +89,22 @@ test("Threshold - reinitializes the observer when changed at runtime", async ({ 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Action - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
+  await page.goto("/action-skip.html");
+  const header = page.locator("header");
+
+  await expect(header).toHaveText(/Element is not in view/);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await expect(header).toHaveText(/Element is not in view/);
+});
+
 test("Action - use:intersect dispatches observe/intersect events and honors once", async ({ page }) => {
   await page.goto("/action.html");
   const app = page.locator("#app");

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -5,7 +5,7 @@
 
   import { type IntersectActionOptions, intersect } from "svelte-intersection-observer";
 
-  let options: IntersectActionOptions = { once: true, rootMargin: "0px", threshold: 0 };
+  let options: IntersectActionOptions = { once: true, rootMargin: "0px", threshold: 0, skip: false };
 </script>
 
 <div


### PR DESCRIPTION
Adds a skip prop/option to IntersectionObserver, MultipleIntersectionObserver, and the intersect action. Setting skip to true unobserves the current element(s) without disconnecting the underlying observer or resetting bound state (intersecting, entry, elementIntersections, elementEntries). Setting it back to false resumes observing and immediately reflects the current intersection state, unlike once, which is a one-way stop.

This mirrors the skip option in react-intersection-observer's useInView, which has the same "preserve last known state while paused" semantics.

Test plan
- bun run test:types passes
- bun run test:e2e passes (skip tests added for all three APIs, plus full existing suite)
- bun run lint clean