### PR TITLE
chore(biome): remove custom print width, reformat with defaults

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -10,8 +10,7 @@
   },
   "formatter": {
     "attributePosition": "multiline",
-    "indentStyle": "space",
-    "lineWidth": 120
+    "indentStyle": "space"
   },
   "html": {
     "experimentalFullSupportEnabled": true,

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -116,7 +116,11 @@
       else observer?.observe(element);
     }
 
-    if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
+    if (
+      rootMargin !== prevRootMargin ||
+      threshold !== prevThreshold ||
+      root !== prevRoot
+    ) {
       observer?.disconnect();
       prevElement = null;
       initialize();

--- a/src/IntersectionObserver.svelte.d.ts
+++ b/src/IntersectionObserver.svelte.d.ts
@@ -73,7 +73,9 @@ export default class extends SvelteComponentTyped<
      * Dispatched only when the element is intersecting the viewport.
      * `event.detail.isIntersecting` will only be `true`
      */
-    intersect: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>;
+    intersect: CustomEvent<
+      IntersectionObserverEntry & { isIntersecting: true }
+    >;
   },
   {
     default: {

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -111,14 +111,18 @@
     await tick();
 
     if (elements.length > 0) {
-      const newElements = elements.filter((el) => el && !prevElements.includes(el));
+      const newElements = elements.filter(
+        (el) => el && !prevElements.includes(el),
+      );
       if (!skip) {
         for (const el of newElements) {
           if (el) observer?.observe(el);
         }
       }
 
-      const removedElements = prevElements.filter((el) => el && !elements.includes(el));
+      const removedElements = prevElements.filter(
+        (el) => el && !elements.includes(el),
+      );
       for (const el of removedElements) {
         if (el) observer?.unobserve(el);
       }
@@ -134,7 +138,11 @@
       }
     }
 
-    if (rootMargin !== prevRootMargin || threshold !== prevThreshold || root !== prevRoot) {
+    if (
+      rootMargin !== prevRootMargin ||
+      threshold !== prevThreshold ||
+      root !== prevRoot
+    ) {
       observer?.disconnect();
       prevElements = [];
       initialize();

--- a/src/intersect.d.ts
+++ b/src/intersect.d.ts
@@ -46,6 +46,8 @@ export const intersect: Action<
   IntersectActionOptions | undefined,
   {
     "on:observe"?: (event: CustomEvent<IntersectionObserverEntry>) => void;
-    "on:intersect"?: (event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>) => void;
+    "on:intersect"?: (
+      event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>,
+    ) => void;
   }
 >;

--- a/src/intersect.js
+++ b/src/intersect.js
@@ -6,7 +6,13 @@
  * @param {import("./intersect.d.ts").IntersectActionOptions} [options]
  */
 export function intersect(node, options = {}) {
-  let { root = null, rootMargin = "0px", threshold = 0, once = false, skip = false } = options;
+  let {
+    root = null,
+    rootMargin = "0px",
+    threshold = 0,
+    once = false,
+    skip = false,
+  } = options;
 
   /** @type {IntersectionObserver} */
   let observer;

--- a/tests/e2e/fixtures/EachBindingFixture.svelte
+++ b/tests/e2e/fixtures/EachBindingFixture.svelte
@@ -2,9 +2,21 @@
   import IntersectionObserver from "svelte-intersection-observer";
 
   const sections = [
-    { id: "one", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
-    { id: "two", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
-    { id: "three", node: undefined as undefined | HTMLElement, intersecting: undefined as undefined | boolean },
+    {
+      id: "one",
+      node: undefined as undefined | HTMLElement,
+      intersecting: undefined as undefined | boolean,
+    },
+    {
+      id: "two",
+      node: undefined as undefined | HTMLElement,
+      intersecting: undefined as undefined | boolean,
+    },
+    {
+      id: "three",
+      node: undefined as undefined | HTMLElement,
+      intersecting: undefined as undefined | boolean,
+    },
   ];
 </script>
 

--- a/tests/e2e/fixtures/MultipleBindingFixture.svelte
+++ b/tests/e2e/fixtures/MultipleBindingFixture.svelte
@@ -6,7 +6,9 @@
   let elementIntersections = new Map<HTMLElement | null, boolean>();
 
   $: elements = [ref1, ref2];
-  $: anyItemVisible = Array.from(elementIntersections.values()).some((visible) => visible);
+  $: anyItemVisible = Array.from(elementIntersections.values()).some(
+    (visible) => visible,
+  );
 </script>
 
 <MultipleIntersectionObserver

--- a/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
@@ -26,8 +26,12 @@
     >
       Remove item 1
     </button>
-    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
-    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-1-status">
+      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-2-status">
+      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
+    </p>
   </header>
 
   <div style="display: flex; margin-top: calc(100vh + 1px);">

--- a/tests/e2e/fixtures/MultipleFixture.svelte
+++ b/tests/e2e/fixtures/MultipleFixture.svelte
@@ -18,7 +18,9 @@
       {#if visible}
         <p data-testid="item-{index + 1}-status">Item {index + 1} is visible</p>
       {:else}
-        <p data-testid="item-{index + 1}-status">Item {index + 1} is not visible</p>
+        <p data-testid="item-{index + 1}-status">
+          Item {index + 1} is not visible
+        </p>
       {/if}
     {/each}
   </header>

--- a/tests/e2e/fixtures/MultipleOnceFixture.svelte
+++ b/tests/e2e/fixtures/MultipleOnceFixture.svelte
@@ -19,8 +19,12 @@
   }}
 >
   <header>
-    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
-    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-1-status">
+      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-2-status">
+      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
+    </p>
     <p data-testid="item-1-count">Item 1 intersect count: {intersectCount1}</p>
     <p data-testid="item-2-count">Item 2 intersect count: {intersectCount2}</p>
   </header>

--- a/tests/e2e/fixtures/MultipleSkipFixture.svelte
+++ b/tests/e2e/fixtures/MultipleSkipFixture.svelte
@@ -14,8 +14,12 @@
   let:elementIntersections
 >
   <header>
-    <p data-testid="item-1-status">Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}</p>
-    <p data-testid="item-2-status">Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}</p>
+    <p data-testid="item-1-status">
+      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
+    </p>
+    <p data-testid="item-2-status">
+      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
+    </p>
     <button
       data-testid="toggle-skip"
       on:click={() => (skip = !skip)}

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -28,20 +28,28 @@ test("Once", async ({ page }) => {
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Once - does not re-dispatch intersect on unrelated updates", async ({ page }) => {
+test("Once - does not re-dispatch intersect on unrelated updates", async ({
+  page,
+}) => {
   await page.goto("/once.html");
 
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 0/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 0/,
+  );
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   await expect(page.locator("header")).toHaveText(/Element is in view/);
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
 
   await page.getByTestId("unrelated-button").click();
   await page.getByTestId("unrelated-button").click();
   await page.getByTestId("unrelated-button").click();
 
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
 });
 
 test("Root margin", async ({ page }) => {
@@ -57,7 +65,9 @@ test("Root margin", async ({ page }) => {
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Element - switching the observed element retargets the observer", async ({ page }) => {
+test("Element - switching the observed element retargets the observer", async ({
+  page,
+}) => {
   await page.goto("/element-change.html");
 
   await expect(page.locator("header")).toHaveText(/Element is in view/);
@@ -69,7 +79,9 @@ test("Element - switching the observed element retargets the observer", async ({
   await expect(page.locator("header")).toHaveText(/Element is in view/);
 });
 
-test("Root margin - reinitializes the observer when changed at runtime", async ({ page }) => {
+test("Root margin - reinitializes the observer when changed at runtime", async ({
+  page,
+}) => {
   await page.goto("/root-margin-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 200));
@@ -79,7 +91,9 @@ test("Root margin - reinitializes the observer when changed at runtime", async (
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Threshold - reinitializes the observer when changed at runtime", async ({ page }) => {
+test("Threshold - reinitializes the observer when changed at runtime", async ({
+  page,
+}) => {
   await page.goto("/threshold-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 300));
@@ -89,7 +103,9 @@ test("Threshold - reinitializes the observer when changed at runtime", async ({ 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Skip - pauses observing without losing state, resumes on toggle", async ({ page }) => {
+test("Skip - pauses observing without losing state, resumes on toggle", async ({
+  page,
+}) => {
   await page.goto("/skip.html");
   const header = page.locator("header");
 
@@ -105,22 +121,34 @@ test("Skip - pauses observing without losing state, resumes on toggle", async ({
   await expect(header).toHaveText(/Element is not in view/);
 });
 
-test("Multiple elements - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
+test("Multiple elements - skip pauses observing without losing state, resumes on toggle", async ({
+  page,
+}) => {
   await page.goto("/multiple-skip.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
 
   await page.getByTestId("toggle-skip").click();
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
 
   await page.getByTestId("toggle-skip").click();
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
 });
 
-test("Action - skip pauses observing without losing state, resumes on toggle", async ({ page }) => {
+test("Action - skip pauses observing without losing state, resumes on toggle", async ({
+  page,
+}) => {
   await page.goto("/action-skip.html");
   const header = page.locator("header");
 
@@ -136,25 +164,35 @@ test("Action - skip pauses observing without losing state, resumes on toggle", a
   await expect(header).toHaveText(/Element is not in view/);
 });
 
-test("Action - use:intersect dispatches observe/intersect events and honors once", async ({ page }) => {
+test("Action - use:intersect dispatches observe/intersect events and honors once", async ({
+  page,
+}) => {
   await page.goto("/action.html");
   const app = page.locator("#app");
 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 0/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 0/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
   await expect(page.locator("header")).toHaveText(/Element is in view/);
   await expect(app).toHaveText(/Hello world/);
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, 0));
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("intersect-count")).toHaveText(/Intersect count: 1/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
 });
 
-test("Action - reinitializes the observer when the parameter changes at runtime", async ({ page }) => {
+test("Action - reinitializes the observer when the parameter changes at runtime", async ({
+  page,
+}) => {
   await page.goto("/action-root-margin-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 200));
@@ -164,7 +202,9 @@ test("Action - reinitializes the observer when the parameter changes at runtime"
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({ page }) => {
+test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({
+  page,
+}) => {
   await page.goto("/multiple-root-margin-change.html");
 
   await page.evaluate(() => window.scrollTo(0, 200));
@@ -174,7 +214,9 @@ test("Multiple elements - reinitializes the observer when root margin changes at
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
-test("Root - uses a custom scroll container instead of the viewport", async ({ page }) => {
+test("Root - uses a custom scroll container instead of the viewport", async ({
+  page,
+}) => {
   await page.goto("/root.html");
   const app = page.locator("#app");
 
@@ -188,7 +230,9 @@ test("Root - uses a custom scroll container instead of the viewport", async ({ p
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Multiple elements - uses a custom scroll container instead of the viewport", async ({ page }) => {
+test("Multiple elements - uses a custom scroll container instead of the viewport", async ({
+  page,
+}) => {
   await page.goto("/multiple-root.html");
 
   await expect(page.getByTestId("status")).toHaveText(/Element is not in view/);
@@ -200,7 +244,9 @@ test("Multiple elements - uses a custom scroll container instead of the viewport
   await expect(page.getByTestId("status")).toHaveText(/Element is in view/);
 });
 
-test("Threshold - requires a minimum visible ratio before intersecting", async ({ page }) => {
+test("Threshold - requires a minimum visible ratio before intersecting", async ({
+  page,
+}) => {
   await page.goto("/threshold.html");
   const app = page.locator("#app");
 
@@ -214,7 +260,9 @@ test("Threshold - requires a minimum visible ratio before intersecting", async (
   await expect(app).toHaveText(/Hello world/);
 });
 
-test("Multiple elements - threshold requires a minimum visible ratio", async ({ page }) => {
+test("Multiple elements - threshold requires a minimum visible ratio", async ({
+  page,
+}) => {
   await page.goto("/multiple-threshold.html");
 
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
@@ -229,67 +277,129 @@ test("Multiple elements - threshold requires a minimum visible ratio", async ({ 
 test("Multiple elements", async ({ page }) => {
   await page.goto("/multiple.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
-  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is visible/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-3-status")).toHaveText(/Item 3 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
 });
 
 test("Multiple elements - once", async ({ page }) => {
   await page.goto("/multiple-once.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 0/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 0/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
-  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 1/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 1/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
-  await expect(page.getByTestId("item-1-count")).toHaveText(/Item 1 intersect count: 1/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-1-count")).toHaveText(
+    /Item 1 intersect count: 1/,
+  );
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-2-count")).toHaveText(/Item 2 intersect count: 0/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-count")).toHaveText(
+    /Item 2 intersect count: 0/,
+  );
 });
 
-test("Multiple elements - elements array add/remove retargets the observer", async ({ page }) => {
+test("Multiple elements - elements array add/remove retargets the observer", async ({
+  page,
+}) => {
   await page.goto("/multiple-elements-change.html");
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is not visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
 
   await page.getByTestId("add-item-2").click();
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is visible/,
+  );
 
   await page.getByTestId("remove-item-1").click();
   await page.evaluate(() => window.scrollTo(0, 0));
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is not visible/);
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
 });
 
 test("Multiple elements - basic pattern", async ({ page }) => {
@@ -302,13 +412,19 @@ test("Multiple elements - basic pattern", async ({ page }) => {
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✓/);
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✗/);
 
-  await expect(page.getByTestId("item-1-indicator")).toHaveClass(/intersecting/);
-  await expect(page.getByTestId("item-2-indicator")).not.toHaveClass(/intersecting/);
+  await expect(page.getByTestId("item-1-indicator")).toHaveClass(
+    /intersecting/,
+  );
+  await expect(page.getByTestId("item-2-indicator")).not.toHaveClass(
+    /intersecting/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✓/);
-  await expect(page.getByTestId("item-2-indicator")).toHaveClass(/intersecting/);
+  await expect(page.getByTestId("item-2-indicator")).toHaveClass(
+    /intersecting/,
+  );
 
   await page.evaluate(() => window.scrollTo(0, 0));
   await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
@@ -325,17 +441,23 @@ test("Each block - bind:this + bind:intersecting per item does not deadlock and 
   await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
-  await expect(page.getByTestId("section-one")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-one")).toHaveText(/visible/, {
+    timeout: 5_000,
+  });
   await expect(page.getByTestId("section-two")).toHaveText(/not visible/);
   await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2.5 + 50));
-  await expect(page.getByTestId("section-two")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-two")).toHaveText(/visible/, {
+    timeout: 5_000,
+  });
   await expect(page.getByTestId("section-one")).toHaveText(/not visible/);
   await expect(page.getByTestId("section-three")).toHaveText(/not visible/);
 
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
-  await expect(page.getByTestId("section-three")).toHaveText(/visible/, { timeout: 5_000 });
+  await expect(page.getByTestId("section-three")).toHaveText(/visible/, {
+    timeout: 5_000,
+  });
   await expect(page.getByTestId("section-one")).toHaveText(/not visible/);
   await expect(page.getByTestId("section-two")).toHaveText(/not visible/);
 });
@@ -343,37 +465,82 @@ test("Each block - bind:this + bind:intersecting per item does not deadlock and 
 test("Multiple elements - binding pattern", async ({ page }) => {
   await page.goto("/multiple-binding.html");
 
-  await expect(page.getByTestId("header-status")).toHaveText(/No items visible/);
-  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "false");
+  await expect(page.getByTestId("header-status")).toHaveText(
+    /No items visible/,
+  );
+  await expect(page.getByTestId("header")).toHaveAttribute(
+    "data-any-visible",
+    "false",
+  );
   await expect(page.getByTestId("header")).not.toHaveClass(/intersecting/);
 
-  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
-  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("item-1")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
+  await expect(page.getByTestId("item-2")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
 
-  await expect(page.getByTestId("header-status")).toHaveText(/At least one item is visible/);
-  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "true");
+  await expect(page.getByTestId("header-status")).toHaveText(
+    /At least one item is visible/,
+  );
+  await expect(page.getByTestId("header")).toHaveAttribute(
+    "data-any-visible",
+    "true",
+  );
   await expect(page.getByTestId("header")).toHaveClass(/intersecting/);
 
-  await expect(page.getByTestId("item-1-status")).toHaveText(/Item 1 is visible/);
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
 
-  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "true");
+  await expect(page.getByTestId("item-1")).toHaveAttribute(
+    "data-visible",
+    "true",
+  );
   await expect(page.getByTestId("item-1")).toHaveClass(/visible/);
-  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("item-2")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
 
   await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
 
-  await expect(page.getByTestId("header-status")).toHaveText(/At least one item is visible/);
+  await expect(page.getByTestId("header-status")).toHaveText(
+    /At least one item is visible/,
+  );
 
-  await expect(page.getByTestId("item-2-status")).toHaveText(/Item 2 is visible/);
-  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "true");
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is visible/,
+  );
+  await expect(page.getByTestId("item-2")).toHaveAttribute(
+    "data-visible",
+    "true",
+  );
   await expect(page.getByTestId("item-2")).toHaveClass(/visible/);
-  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("item-1")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
 
   await page.evaluate(() => window.scrollTo(0, 0));
-  await expect(page.getByTestId("header-status")).toHaveText(/No items visible/);
-  await expect(page.getByTestId("header")).toHaveAttribute("data-any-visible", "false");
-  await expect(page.getByTestId("item-1")).toHaveAttribute("data-visible", "false");
-  await expect(page.getByTestId("item-2")).toHaveAttribute("data-visible", "false");
+  await expect(page.getByTestId("header-status")).toHaveText(
+    /No items visible/,
+  );
+  await expect(page.getByTestId("header")).toHaveAttribute(
+    "data-any-visible",
+    "false",
+  );
+  await expect(page.getByTestId("item-1")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
+  await expect(page.getByTestId("item-2")).toHaveAttribute(
+    "data-visible",
+    "false",
+  );
 });

--- a/tests/e2e/vite.config.ts
+++ b/tests/e2e/vite.config.ts
@@ -6,7 +6,9 @@ import { defineConfig } from "vite";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const fixtures = path.resolve(__dirname, "fixtures");
-const pkg = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf-8"));
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf-8"),
+);
 
 // Every fixture .html is its own entry point so `vite build` emits the full
 // multi-page app. The dev server discovers these automatically, but the
@@ -15,7 +17,10 @@ const input = Object.fromEntries(
   fs
     .readdirSync(fixtures)
     .filter((file) => file.endsWith(".html"))
-    .map((file) => [file.slice(0, -".html".length), path.resolve(fixtures, file)]),
+    .map((file) => [
+      file.slice(0, -".html".length),
+      path.resolve(fixtures, file),
+    ]),
 );
 
 export default defineConfig({

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -3,9 +3,17 @@
    * Run `bun test:types` to test the type definitions of the action using `svelte-check`.
    */
 
-  import { type IntersectActionOptions, intersect } from "svelte-intersection-observer";
+  import {
+    type IntersectActionOptions,
+    intersect,
+  } from "svelte-intersection-observer";
 
-  let options: IntersectActionOptions = { once: true, rootMargin: "0px", threshold: 0, skip: false };
+  let options: IntersectActionOptions = {
+    once: true,
+    rootMargin: "0px",
+    threshold: 0,
+    skip: false,
+  };
 </script>
 
 <div


### PR DESCRIPTION
Drop the 120-char lineWidth override so formatting matches
Biome's default (80), and re-run `biome check --write .` to
apply the change across the codebase.