### PR TITLE
ci: split lint/type-check from e2e into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,29 @@ on:
     branches: [master]
 
 jobs:
-  test-and-deploy-docs:
-    name: Test & Deploy Docs
+  checks:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      # --ignore-scripts skips Playwright's browser download; this job never
+      # runs e2e tests, so browsers aren't needed.
+      - name: Install dependencies
+        run: bun ci --ignore-scripts
+
+      - name: Run Biome
+        run: bunx biome ci --error-on-warnings
+
+      - name: Check types
+        run: bun run test:types
+
+  e2e:
+    name: E2E Tests
     runs-on: ubuntu-latest
     # Official image includes Chromium/Firefox/WebKit + system deps.
     # Bump tag with @playwright/test in package.json.
@@ -32,21 +53,28 @@ jobs:
       - name: Install dependencies
         run: bun ci --ignore-scripts
 
-      - name: Run Biome
-        run: bunx biome ci --error-on-warnings
-
-      - name: Check types
-        run: bun run test:types
-
       - name: Run e2e tests
         run: bun run test:e2e
 
+  deploy-docs:
+    name: Deploy Docs
+    needs: [checks, e2e]
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install dependencies
+        run: bun ci --ignore-scripts
+
       - name: Build documentation
-        if: github.ref == 'refs/heads/master'
         run: bun run build
 
       - name: Deploy documentation
-        if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Splits the single `test-and-deploy-docs` job into three: `checks` (Biome + type check on plain `ubuntu-latest`), `e2e` (Playwright container, keeps its own unzip/bun/deps setup grouped together), and `deploy-docs` (needs both, still gated to `master`).
- Fast checks now report failures without waiting on the Playwright container pull and e2e run, since GitHub Actions runs independent jobs in parallel.

## Why not just reorder steps
In the original single job, `bun ci` had to run before Biome/types *and* before e2e — so no step-level reorder changes fail-fast behavior. Splitting into jobs was the only way to actually decouple the fast checks from the slow e2e setup.

