### PR TITLE
fix(npm-package): rewrite svelte field to match flattened package layout

### DIFF
--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -14,6 +14,7 @@ await $`cp -r ./src/* ./package/`;
 
 const { scripts, devDependencies, ...pkgJson } = await pkg.json();
 
+pkgJson.svelte = "./index.js";
 pkgJson.main = "./index.js";
 pkgJson.types = "./index.d.ts";
 pkgJson.exports = {


### PR DESCRIPTION
## Summary
- The REPL fails to compile with `Could not find src/index.js in svelte-intersection-observer@1.1.1` because the published package.json's `svelte` field still points to `./src/index.js`, a path that doesn't exist once the package is flattened (`src/*` is copied to the package root during publish).
- `scripts/npm-package.ts` already rewrites `main`, `types`, and `exports` to the flattened `./index.js` path but missed the top-level `svelte` field, which was carried over verbatim from the source `package.json`.
- Adds `pkgJson.svelte = "./index.js";` so the legacy `svelte` field (used by tools like the Svelte REPL) matches the actual published layout.

## Test plan
- [x] Ran `bun scripts/npm-package.ts` and confirmed `package/package.json` now has `"svelte": "./index.js"`
- [ ] Publish a new patch release and confirm the REPL compiles again