### PR TITLE
docs(readme): fix ambiguous self-closing header tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In the following example, the "Hello world" element will fade in when its contai
   let node;
 </script>
 
-<header />
+<header></header>
 
 <IntersectionObserver element={node} let:intersecting>
   <div bind:this={node}>


### PR DESCRIPTION
## Summary
- `bun run build` emitted a vite-plugin-svelte warning: self-closing `<header />` is ambiguous for non-void elements.
- Replace with explicit `<header></header>` in the README's `let:intersecting` example.

## Test plan
- [x] `bun run build` completes with no warnings