### PR TITLE
docs(readme): make each demo container fill its code-fence

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,11 +255,10 @@ This avoids instantiating a new observer for every element.
 <script>
   import { MultipleIntersectionObserver } from "svelte-intersection-observer";
 
-  let items = [
-    { id: 1, text: "Item 1" },
-    { id: 2, text: "Item 2" },
-    { id: 3, text: "Item 3" },
-  ];
+  let items = Array.from({ length: 10 }, (_, i) => ({
+    id: i + 1,
+    text: `Item ${i + 1}`,
+  }));
 
   let refs = [];
   let itemsContainer;
@@ -280,11 +279,14 @@ This avoids instantiating a new observer for every element.
     {/each}
   </header>
 
-  <div bind:this={itemsContainer} style="height: 150px; overflow-y: auto;">
+  <div
+    bind:this={itemsContainer}
+    style="height: 150px; overflow-y: auto; display: flex; flex-direction: column; gap: 1rem;"
+  >
     {#each items as item, i (item.id)}
       <div
         bind:this={refs[i]}
-        style="height: 100px; display: flex; align-items: center;"
+        style="height: 100px; display: flex; align-items: center; flex-shrink: 0;"
       >
         {item.text}
       </div>
@@ -374,13 +376,13 @@ The `e.detail` for both events includes:
 
 #### Options
 
-| Name       | Description                                                  | Type                                                                | Default value |
-| :--------- | :------------------------------------------------------------ | :------------------------------------------------------------------- | :------------- |
-| root       | Containing element                                            | `null` or `HTMLElement`                                             | `null`         |
-| rootMargin | Margin offset of the containing element                       | `string`                                                            | `"0px"`        |
-| threshold  | Percentage of element visibility to trigger an event          | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`            |
-| once       | Unobserve the element after the first intersection event      | `boolean`                                                           | `false`        |
-| skip       | Pause observing without disconnecting the observer            | `boolean`                                                           | `false`        |
+| Name       | Description                                              | Type                                                               | Default value |
+| :--------- | :------------------------------------------------------- | :----------------------------------------------------------------- | :------------ |
+| root       | Containing element                                       | `null` or `HTMLElement`                                            | `null`        |
+| rootMargin | Margin offset of the containing element                  | `string`                                                           | `"0px"`       |
+| threshold  | Percentage of element visibility to trigger an event     | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`           |
+| once       | Unobserve the element after the first intersection event | `boolean`                                                          | `false`       |
+| skip       | Pause observing without disconnecting the observer       | `boolean`                                                          | `false`       |
 
 #### Dispatched events
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
     svelteReadme({
       style: `
         .code-fence {
-          overflow-y: scroll;
+          display: flex;
+          flex-direction: column;
+          overflow-y: auto;
           height: 50vh;
           min-height: 380px;
           padding: 0;
@@ -21,6 +23,7 @@ export default defineConfig({
           width: 100%;
           padding: 1rem;
           background-color: #e0f7f6;
+          flex-shrink: 0;
         }
 
         header:before {
@@ -30,11 +33,20 @@ export default defineConfig({
         }
 
         .code-fence header ~ div {
-          margin-top: 50vh;
-          height: 25vh;
           padding: 1rem;
           background-color: #376462;
           color: #fff;
+        }
+
+        .code-fence header ~ div:not([style*="overflow"]) {
+          margin-top: 50vh;
+          height: 25vh;
+          flex-shrink: 0;
+        }
+
+        .code-fence header ~ div[style*="overflow"] {
+          flex: 1;
+          min-height: 0;
         }
 
         .code-fence header {


### PR DESCRIPTION
- The code-fence demo wrapper is now a flex column; demo containers that declare their own `overflow` (scroll-to-end, `#each`) stretch to fill the remaining space via `flex: 1` instead of leaving dead space below them or forcing a second, redundant scrollbar on the outer wrapper.
- The `#each` example now generates 10 items (`Array.from({ length: 10 }, ...)`) instead of 3, so the list still overflows its now taller container and genuinely requires scrolling to see later items, rather than showing everything as intersecting immediately.
- Item divs in the `#each` example get a `gap: 1rem` from their siblings instead of sitting flush against each other.

