### PR TITLE
Port to Svelte 5 runes (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Breaking Changes**
+
+- Port `IntersectionObserver` and `MultipleIntersectionObserver` to Svelte 5 runes; requires `svelte@^5` in runes mode
+- Replace the default `<slot>` with a `children` snippet — use `{#snippet children({ intersecting, entry, observer })}` instead of `let:intersecting`/`let:entry`/`let:observer` (and `let:elementIntersections`/`let:elementEntries`/`let:observer` for `MultipleIntersectionObserver`)
+- Replace `on:observe`/`on:intersect` dispatched events with `onobserve`/`onintersect` callback props, called directly with the `IntersectionObserverEntry` (or `{ entry, target }` for `MultipleIntersectionObserver`) instead of a `CustomEvent`
+- `use:intersect` now listens via `onobserve`/`onintersect` attributes instead of `on:observe`/`on:intersect` (the action itself still dispatches native `CustomEvent`s)
+- Rename `src/intersect.js`/`src/intersect.d.ts` to `src/intersect.svelte.js`/`src/intersect.svelte.d.ts`
+
 ## [1.2.0](https://github.com/metonym/svelte-intersection-observer/releases/tag/v1.2.0) - 2026-07-04
 
 **Features**

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 Try it in the [Svelte REPL](https://svelte.dev/repl/8cd2327a580c4f429c71f7df999bd51d).
 
+## Compatibility
+
+| Package version | Svelte version    | Notes                                     |
+| :--------------- | :----------------- | :----------------------------------------- |
+| 1.x              | 3, 4, 5 (non-runes) | Uses `export let`, slots, and `on:` events |
+| 2.x              | 5 (runes mode only) | Uses `$props()`, snippets, and callback props |
+
 <!-- TOC -->
 
 ## Installation
@@ -37,8 +44,8 @@ Then, simply bind to the reactive `intersecting` prop to determine if the elemen
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let element;
-  let intersecting;
+  let element = $state();
+  let intersecting = $state(false);
 </script>
 
 <header class:intersecting>
@@ -58,8 +65,8 @@ Set `once` to `true` for the intersection event to occur only once. The `element
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let elementOnce;
-  let intersectOnce;
+  let elementOnce = $state();
+  let intersectOnce = $state(false);
 </script>
 
 <header class:intersecting={intersectOnce}>
@@ -83,22 +90,24 @@ Set `skip` to `true` to unobserve without disconnecting the underlying observer 
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let elementSkip;
-  let paused = false;
+  let elementSkip = $state();
+  let paused = $state(false);
 </script>
 
-<button on:click={() => (paused = !paused)}>
+<button onclick={() => (paused = !paused)}>
   {paused ? "Resume" : "Pause"}
 </button>
 
-<IntersectionObserver element={elementSkip} skip={paused} let:intersecting>
-  <div bind:this={elementSkip}>{intersecting ? "In view" : "Not in view"}</div>
+<IntersectionObserver element={elementSkip} skip={paused}>
+  {#snippet children({ intersecting })}
+    <div bind:this={elementSkip}>{intersecting ? "In view" : "Not in view"}</div>
+  {/snippet}
 </IntersectionObserver>
 ```
 
-### `let:intersecting`
+### `children` snippet
 
-An alternative to binding to the `intersecting` prop is to use the `let:` directive.
+An alternative to binding to the `intersecting` prop is to use the `children` snippet, which receives `intersecting`, `entry`, and `observer`.
 
 In the following example, the "Hello world" element will fade in when its containing element intersects the viewport.
 
@@ -107,48 +116,50 @@ In the following example, the "Hello world" element will fade in when its contai
   import IntersectionObserver from "svelte-intersection-observer";
   import { fade } from "svelte/transition";
 
-  let node;
+  let node = $state();
 </script>
 
 <header></header>
 
-<IntersectionObserver element={node} let:intersecting>
-  <div bind:this={node}>
-    {#if intersecting}
-      <div transition:fade={{ delay: 200 }}>Hello world</div>
-    {/if}
-  </div>
+<IntersectionObserver element={node}>
+  {#snippet children({ intersecting })}
+    <div bind:this={node}>
+      {#if intersecting}
+        <div transition:fade={{ delay: 200 }}>Hello world</div>
+      {/if}
+    </div>
+  {/snippet}
 </IntersectionObserver>
 ```
 
-### `on:observe` event
+### `onobserve` callback prop
 
-The `observe` event is dispatched when the element is first observed and also whenever an intersection event occurs.
+`onobserve` is called when the element is first observed and also whenever an intersection event occurs.
 
 ```svelte no-eval
 <IntersectionObserver
   {element}
-  on:observe={(e) => {
-    console.log(e.detail); // IntersectionObserverEntry
-    console.log(e.detail.isIntersecting); // true | false
+  onobserve={(entry) => {
+    console.log(entry); // IntersectionObserverEntry
+    console.log(entry.isIntersecting); // true | false
   }}
 >
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>
 ```
 
-### `on:intersect` event
+### `onintersect` callback prop
 
-As an alternative to binding the `intersecting` prop, you can listen to the `intersect` event that is dispatched if the observed element is intersecting the viewport.
+As an alternative to binding the `intersecting` prop, you can pass an `onintersect` callback that is called if the observed element is intersecting the viewport.
 
-**Note**: Compared to `on:observe`, `on:intersect` is dispatched only when the element is _intersecting the viewport_. In other words, `e.detail.isIntersecting` will only be `true`.
+**Note**: Compared to `onobserve`, `onintersect` is called only when the element is _intersecting the viewport_. In other words, `entry.isIntersecting` will only be `true`.
 
 ```svelte no-eval
 <IntersectionObserver
   {element}
-  on:intersect={(e) => {
-    console.log(e.detail); // IntersectionObserverEntry
-    console.log(e.detail.isIntersecting); // true
+  onintersect={(entry) => {
+    console.log(entry); // IntersectionObserverEntry
+    console.log(entry.isIntersecting); // true
   }}
 >
   <div bind:this={element}>Hello world</div>
@@ -165,9 +176,9 @@ To detect when a user has scrolled to the end of a scrollable container, place a
 <script>
   import IntersectionObserver from "svelte-intersection-observer";
 
-  let container;
-  let sentinel;
-  let reachedEnd;
+  let container = $state();
+  let sentinel = $state();
+  let reachedEnd = $state(false);
 </script>
 
 <header class:intersecting={reachedEnd}>
@@ -198,23 +209,23 @@ Keep the `bind:this` element outside the `{#if intersecting}` block, and only ga
   import IntersectionObserver from "svelte-intersection-observer";
   import { fly } from "svelte/transition";
 
-  let node;
-  let intersecting;
+  let revealNode = $state();
+  let revealIntersecting = $state(false);
 </script>
 
-<header class:intersecting>
+<header class:intersecting={revealIntersecting}>
   <button
-    on:click={() => {
-      node.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    onclick={() => {
+      revealNode.scrollIntoView({ behavior: "smooth", block: "nearest" });
     }}
   >
     Scroll to section
   </button>
 </header>
 
-<IntersectionObserver element={node} once bind:intersecting>
-  <div bind:this={node}>
-    {#if intersecting}
+<IntersectionObserver element={revealNode} once bind:intersecting={revealIntersecting}>
+  <div bind:this={revealNode}>
+    {#if revealIntersecting}
       <section transition:fly={{ y: 50, delay: 200, duration: 300 }}>
         Hello world
       </section>
@@ -225,13 +236,13 @@ Keep the `bind:this` element outside the `{#if intersecting}` block, and only ga
 
 ### `use:intersect` action
 
-As an alternative to the `IntersectionObserver` component, use the `intersect` action to observe an element directly with `use:`, without a `bind:this` reference or wrapper markup. Listen for `on:observe`/`on:intersect` on the observed element itself.
+As an alternative to the `IntersectionObserver` component, use the `intersect` action to observe an element directly with `use:`, without a `bind:this` reference or wrapper markup. Listen for `onobserve`/`onintersect` on the observed element itself.
 
 ```svelte
 <script>
   import { intersect } from "svelte-intersection-observer";
 
-  let actionIntersecting = false;
+  let actionIntersecting = $state(false);
 </script>
 
 <header class:intersecting={actionIntersecting}>
@@ -240,7 +251,7 @@ As an alternative to the `IntersectionObserver` component, use the `intersect` a
 
 <div
   use:intersect={{ once: true }}
-  on:observe={(e) => (actionIntersecting = e.detail.isIntersecting)}
+  onobserve={(e) => (actionIntersecting = e.detail.isIntersecting)}
 >
   Hello world
 </div>
@@ -258,24 +269,26 @@ This avoids instantiating a new observer for every element.
 <script>
   import { MultipleIntersectionObserver } from "svelte-intersection-observer";
 
-  let ref1;
-  let ref2;
+  let ref1 = $state();
+  let ref2 = $state();
 
-  $: elements = [ref1, ref2];
+  let elements = $derived([ref1, ref2]);
 </script>
 
-<MultipleIntersectionObserver {elements} let:elementIntersections>
-  <header>
-    <div class:intersecting={elementIntersections.get(ref1)}>
-      Item 1: {elementIntersections.get(ref1) ? "✓" : "✗"}
-    </div>
-    <div class:intersecting={elementIntersections.get(ref2)}>
-      Item 2: {elementIntersections.get(ref2) ? "✓" : "✗"}
-    </div>
-  </header>
+<MultipleIntersectionObserver {elements}>
+  {#snippet children({ elementIntersections })}
+    <header>
+      <div class:intersecting={elementIntersections.get(ref1)}>
+        Item 1: {elementIntersections.get(ref1) ? "✓" : "✗"}
+      </div>
+      <div class:intersecting={elementIntersections.get(ref2)}>
+        Item 2: {elementIntersections.get(ref2) ? "✓" : "✗"}
+      </div>
+    </header>
 
-  <div bind:this={ref1}>Item 1</div>
-  <div bind:this={ref2}>Item 2</div>
+    <div bind:this={ref1}>Item 1</div>
+    <div bind:this={ref2}>Item 2</div>
+  {/snippet}
 </MultipleIntersectionObserver>
 ```
 
@@ -292,38 +305,36 @@ This avoids instantiating a new observer for every element.
     text: `Item ${i + 1}`,
   }));
 
-  let refs = [];
-  let itemsContainer;
+  let refs = $state([]);
+  let itemsContainer = $state();
 
-  $: itemElements = refs;
+  let itemElements = $derived(refs);
 </script>
 
-<MultipleIntersectionObserver
-  elements={itemElements}
-  root={itemsContainer}
-  let:elementIntersections
->
-  <header>
-    {#each items as item, i (item.id)}
-      <div class:intersecting={elementIntersections.get(refs[i])}>
-        {item.text}: {elementIntersections.get(refs[i]) ? "✓" : "✗"}
-      </div>
-    {/each}
-  </header>
+<MultipleIntersectionObserver elements={itemElements} root={itemsContainer}>
+  {#snippet children({ elementIntersections })}
+    <header>
+      {#each items as item, i (item.id)}
+        <div class:intersecting={elementIntersections.get(refs[i])}>
+          {item.text}: {elementIntersections.get(refs[i]) ? "✓" : "✗"}
+        </div>
+      {/each}
+    </header>
 
-  <div
-    bind:this={itemsContainer}
-    style="height: 150px; overflow-y: auto; display: flex; flex-direction: column; gap: 1rem;"
-  >
-    {#each items as item, i (item.id)}
-      <div
-        bind:this={refs[i]}
-        style="height: 100px; display: flex; align-items: center; flex-shrink: 0;"
-      >
-        {item.text}
-      </div>
-    {/each}
-  </div>
+    <div
+      bind:this={itemsContainer}
+      style="height: 150px; overflow-y: auto; display: flex; flex-direction: column; gap: 1rem;"
+    >
+      {#each items as item, i (item.id)}
+        <div
+          bind:this={refs[i]}
+          style="height: 100px; display: flex; align-items: center; flex-shrink: 0;"
+        >
+          {item.text}
+        </div>
+      {/each}
+    </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 ```
 
@@ -351,14 +362,14 @@ As with the scroll-to-end example, `root` must be an element that scrolls on its
 
 **Note**: the observed `element` must render with a non-zero width and height for `threshold` values greater than `0` to have any effect — this is a constraint of the underlying [Intersection Observer API](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API), not something this component controls.
 
-#### Dispatched events
+#### Callback props
 
-- **on:observe**: fired when the element is first observed or whenever an intersection change occurs
-- **on:intersect**: fired when the element is intersecting the viewport
+- **onobserve**: called when the element is first observed or whenever an intersection change occurs
+- **onintersect**: called when the element is intersecting the viewport
 
-The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
+Both callbacks are called with an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry).
 
-#### Slot props
+#### `children` snippet props
 
 | Name         | Type                                                                                                                |
 | :----------- | :------------------------------------------------------------------------------------------------------------------ |
@@ -382,12 +393,12 @@ The `e.detail` dispatched by the `observe` and `intersect` events is an [`Inters
 | observer             | `IntersectionObserver` instance                       | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)                               | `null`        |
 | skip                 | Pause observing all elements without losing state     | `boolean`                                                                                                                               | `false`       |
 
-#### Dispatched events
+#### Callback props
 
-- **on:observe**: fired when an element is first observed or whenever an intersection change occurs
-- **on:intersect**: fired when an element is intersecting the viewport
+- **onobserve**: called when an element is first observed or whenever an intersection change occurs
+- **onintersect**: called when an element is intersecting the viewport
 
-The `e.detail` for both events includes:
+Both callbacks are called with:
 
 ```ts
 {
@@ -396,7 +407,7 @@ The `e.detail` for both events includes:
 }
 ```
 
-#### Slot props
+#### `children` snippet props
 
 | Name                 | Type                                                                                                                                    |
 | :------------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
@@ -418,8 +429,8 @@ The `e.detail` for both events includes:
 
 #### Dispatched events
 
-- **on:observe**: fired on the element when it is first observed or whenever an intersection change occurs
-- **on:intersect**: fired on the element when it is intersecting the viewport
+- **onobserve**: fired on the element when it is first observed or whenever an intersection change occurs
+- **onintersect**: fired on the element when it is intersecting the viewport
 
 The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
 

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,74 +1,42 @@
 <script>
-  /**
-   * The HTML Element to observe.
-   * @type {null | HTMLElement}
-   */
-  export let element = null;
+  import { untrack } from "svelte";
 
   /**
-   * Set to `true` to unobserve the element
-   * after it intersects the viewport.
-   * @type {boolean}
+   * @typedef {Object} Props
+   * @property {null | HTMLElement} [element] The HTML Element to observe.
+   * @property {boolean} [once] Set to `true` to unobserve the element after it intersects the viewport.
+   * @property {boolean} [intersecting] `true` if the observed element is intersecting the viewport.
+   * @property {null | HTMLElement} [root] Specify the containing element. Defaults to the browser viewport.
+   * @property {string} [rootMargin] Margin offset of the containing element.
+   * @property {number | number[]} [threshold] Percentage of element visibility to trigger an event. Value must be between 0 and 1.
+   * @property {null | IntersectionObserverEntry} [entry] Observed element metadata.
+   * @property {null | IntersectionObserver} [observer] `IntersectionObserver` instance.
+   * @property {boolean} [skip] Set to `true` to pause observing without disconnecting the observer or losing `entry`/`intersecting` state. Set back to `false` to resume.
+   * @property {(entry: IntersectionObserverEntry) => void} [onobserve] Called when the element is first observed and also whenever an intersection event occurs.
+   * @property {(entry: IntersectionObserverEntry & { isIntersecting: true }) => void} [onintersect] Called only when the observed element is intersecting the viewport.
+   * @property {import("svelte").Snippet<[{ intersecting: boolean, entry: null | IntersectionObserverEntry, observer: null | IntersectionObserver }]>} [children]
    */
-  export let once = false;
 
-  /**
-   * `true` if the observed element
-   * is intersecting the viewport.
-   */
-  export let intersecting = false;
-
-  /**
-   * Specify the containing element.
-   * Defaults to the browser viewport.
-   * @type {null | HTMLElement}
-   */
-  export let root = null;
-
-  /** Margin offset of the containing element. */
-  export let rootMargin = "0px";
-
-  /**
-   * Percentage of element visibility to trigger an event.
-   * Value must be between 0 and 1.
-   */
-  export let threshold = 0;
-
-  /**
-   * Observed element metadata.
-   * @type {null | IntersectionObserverEntry}
-   */
-  export let entry = null;
-
-  /**
-   * `IntersectionObserver` instance.
-   * @type {null | IntersectionObserver}
-   */
-  export let observer = null;
-
-  /**
-   * Set to `true` to pause observing without disconnecting the
-   * observer or losing `entry`/`intersecting` state. Set back to
-   * `false` to resume.
-   * @type {boolean}
-   */
-  export let skip = false;
-
-  import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
-
-  const dispatch = createEventDispatcher();
-
-  let prevRootMargin = rootMargin;
-
-  let prevThreshold = threshold;
-
-  /** @type {null | HTMLElement} */
-  let prevRoot = root;
+  /** @type {Props} */
+  let {
+    element = null,
+    once = false,
+    intersecting = $bindable(false),
+    root = null,
+    rootMargin = "0px",
+    threshold = 0,
+    entry = $bindable(null),
+    observer = $bindable(null),
+    skip = false,
+    onobserve,
+    onintersect,
+    children,
+  } = $props();
 
   /** @type {null | HTMLElement} */
   let prevElement = null;
 
-  let prevSkip = skip;
+  let prevSkip = untrack(() => skip);
 
   const initialize = () => {
     observer = new IntersectionObserver(
@@ -77,10 +45,10 @@
           entry = _entry;
           intersecting = _entry.isIntersecting;
 
-          dispatch("observe", entry);
+          onobserve?.(_entry);
 
           if (_entry.isIntersecting) {
-            dispatch("intersect", entry);
+            onintersect?.(_entry);
 
             if (element && once) observer?.unobserve(element);
           }
@@ -90,53 +58,34 @@
     );
   };
 
-  onMount(() => {
+  $effect(() => {
+    prevElement = null;
     initialize();
 
     return () => {
-      if (observer) {
-        observer.disconnect();
-        observer = null;
-      }
+      observer?.disconnect();
+      observer = null;
     };
   });
 
-  afterUpdate(async () => {
-    await tick();
+  $effect(() => {
+    const target = element;
+    const isSkipped = skip;
+    const activeObserver = observer;
 
-    if (element !== null && element !== prevElement) {
-      if (!skip) observer?.observe(element);
-
-      if (prevElement !== null) observer?.unobserve(prevElement);
-      prevElement = element;
+    if (target !== null && target !== prevElement) {
+      if (!isSkipped) activeObserver?.observe(target);
+      if (prevElement !== null) activeObserver?.unobserve(prevElement);
+      prevElement = target;
     }
 
-    if (skip !== prevSkip && element !== null) {
-      if (skip) observer?.unobserve(element);
-      else observer?.observe(element);
+    if (isSkipped !== prevSkip && target !== null) {
+      if (isSkipped) activeObserver?.unobserve(target);
+      else activeObserver?.observe(target);
     }
 
-    if (
-      rootMargin !== prevRootMargin ||
-      threshold !== prevThreshold ||
-      root !== prevRoot
-    ) {
-      observer?.disconnect();
-      initialize();
-
-      if (element !== null && !skip) observer?.observe(element);
-      prevElement = element;
-    }
-
-    prevRootMargin = rootMargin;
-    prevThreshold = threshold;
-    prevRoot = root;
-    prevSkip = skip;
+    prevSkip = isSkipped;
   });
 </script>
 
-<slot
-  {intersecting}
-  {entry}
-  {observer}
-/>
+{@render children?.({ intersecting, entry, observer })}

--- a/src/IntersectionObserver.svelte.d.ts
+++ b/src/IntersectionObserver.svelte.d.ts
@@ -1,87 +1,95 @@
-import type { SvelteComponentTyped } from "svelte";
+import type { Component, Snippet } from "svelte";
 
-export default class extends SvelteComponentTyped<
-  {
-    /**
-     * The HTML Element to observe.
-     * @default null
-     */
-    element?: null | HTMLElement;
+export interface IntersectionObserverProps {
+  /**
+   * The HTML Element to observe.
+   * @default null
+   */
+  element?: null | HTMLElement;
 
-    /**
-     * Set to `true` to unobserve the element
-     * after it intersects the viewport.
-     * @default false
-     */
-    once?: boolean;
+  /**
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
+   * @default false
+   */
+  once?: boolean;
 
-    /**
-     * `true` if the observed element
-     * is intersecting the viewport.
-     * @default false
-     */
-    intersecting?: boolean;
+  /**
+   * `true` if the observed element
+   * is intersecting the viewport.
+   * @default false
+   */
+  intersecting?: boolean;
 
-    /**
-     * Specify the containing element.
-     * Defaults to the browser viewport.
-     * @default null
-     */
-    root?: null | HTMLElement;
+  /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
+   * @default null
+   */
+  root?: null | HTMLElement;
 
-    /**
-     * Margin offset of the containing element.
-     * @default "0px"
-     */
-    rootMargin?: string;
+  /**
+   * Margin offset of the containing element.
+   * @default "0px"
+   */
+  rootMargin?: string;
 
-    /**
-     * Percentage of element visibility to trigger an event.
-     * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
-     * @default 0
-     */
-    threshold?: number | number[];
+  /**
+   * Percentage of element visibility to trigger an event.
+   * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
+   * @default 0
+   */
+  threshold?: number | number[];
 
-    /**
-     * Observed element metadata.
-     * @default null
-     */
-    entry?: null | IntersectionObserverEntry;
+  /**
+   * Observed element metadata.
+   * @default null
+   */
+  entry?: null | IntersectionObserverEntry;
 
-    /**
-     * `IntersectionObserver` instance.
-     * @default null
-     */
-    observer?: null | IntersectionObserver;
+  /**
+   * `IntersectionObserver` instance.
+   * @default null
+   */
+  observer?: null | IntersectionObserver;
 
-    /**
-     * Set to `true` to pause observing without disconnecting the
-     * observer or losing `entry`/`intersecting` state. Set back to
-     * `false` to resume.
-     * @default false
-     */
-    skip?: boolean;
-  },
-  {
-    /**
-     * Dispatched when the element is first observed
-     * and also whenever an intersection event occurs.
-     */
-    observe: CustomEvent<IntersectionObserverEntry>;
+  /**
+   * Set to `true` to pause observing without disconnecting the
+   * observer or losing `entry`/`intersecting` state. Set back to
+   * `false` to resume.
+   * @default false
+   */
+  skip?: boolean;
 
-    /**
-     * Dispatched only when the element is intersecting the viewport.
-     * `event.detail.isIntersecting` will only be `true`
-     */
-    intersect: CustomEvent<
-      IntersectionObserverEntry & { isIntersecting: true }
-    >;
-  },
-  {
-    default: {
-      intersecting: boolean;
-      entry: null | IntersectionObserverEntry;
-      observer: IntersectionObserver;
-    };
-  }
-> {}
+  /**
+   * Called when the element is first observed
+   * and also whenever an intersection event occurs.
+   */
+  onobserve?: (entry: IntersectionObserverEntry) => void;
+
+  /**
+   * Called only when the element is intersecting the viewport.
+   * `entry.isIntersecting` will always be `true`.
+   */
+  onintersect?: (
+    entry: IntersectionObserverEntry & { isIntersecting: true },
+  ) => void;
+
+  children?: Snippet<
+    [
+      {
+        intersecting: boolean;
+        entry: null | IntersectionObserverEntry;
+        observer: null | IntersectionObserver;
+      },
+    ]
+  >;
+}
+
+declare const IntersectionObserverComponent: Component<
+  IntersectionObserverProps,
+  Record<string, never>,
+  "intersecting" | "entry" | "observer"
+>;
+
+export default IntersectionObserverComponent;

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -1,75 +1,42 @@
 <script>
-  /**
-   * Array of HTML Elements to observe.
-   * Use this for better performance when observing multiple elements.
-   * @type {(HTMLElement | null)[]}
-   */
-  export let elements = [];
+  import { untrack } from "svelte";
 
   /**
-   * Set to `true` to unobserve the element
-   * after it intersects the viewport.
-   * @type {boolean}
+   * @typedef {Object} Props
+   * @property {(HTMLElement | null)[]} [elements] Array of HTML Elements to observe. Use this for better performance when observing multiple elements.
+   * @property {boolean} [once] Set to `true` to unobserve the element after it intersects the viewport.
+   * @property {null | HTMLElement} [root] Specify the containing element. Defaults to the browser viewport.
+   * @property {string} [rootMargin] Margin offset of the containing element.
+   * @property {number | number[]} [threshold] Percentage of element visibility to trigger an event. Value must be between 0 and 1.
+   * @property {Map<HTMLElement | null, boolean>} [elementIntersections] Map of element to its intersection state.
+   * @property {Map<HTMLElement | null, IntersectionObserverEntry>} [elementEntries] Map of element to its latest entry.
+   * @property {null | IntersectionObserver} [observer] `IntersectionObserver` instance.
+   * @property {boolean} [skip] Set to `true` to pause observing all elements without disconnecting the observer or losing `elementIntersections`/`elementEntries` state. Set back to `false` to resume.
+   * @property {(detail: { entry: IntersectionObserverEntry, target: HTMLElement }) => void} [onobserve] Called when an element is first observed and also whenever an intersection event occurs.
+   * @property {(detail: { entry: IntersectionObserverEntry & { isIntersecting: true }, target: HTMLElement }) => void} [onintersect] Called only when an element is intersecting the viewport.
+   * @property {import("svelte").Snippet<[{ observer: null | IntersectionObserver, elementIntersections: Map<HTMLElement | null, boolean>, elementEntries: Map<HTMLElement | null, IntersectionObserverEntry> }]>} [children]
    */
-  export let once = false;
 
-  /**
-   * Specify the containing element.
-   * Defaults to the browser viewport.
-   * @type {null | HTMLElement}
-   */
-  export let root = null;
-
-  /** Margin offset of the containing element. */
-  export let rootMargin = "0px";
-
-  /**
-   * Percentage of element visibility to trigger an event.
-   * Value must be between 0 and 1.
-   */
-  export let threshold = 0;
-
-  /**
-   * Map of element to its intersection state.
-   * @type {Map<HTMLElement | null, boolean>}
-   */
-  export let elementIntersections = new Map();
-
-  /**
-   * Map of element to its latest entry.
-   * @type {Map<HTMLElement | null, IntersectionObserverEntry>}
-   */
-  export let elementEntries = new Map();
-
-  /**
-   * `IntersectionObserver` instance.
-   * @type {null | IntersectionObserver}
-   */
-  export let observer = null;
-
-  /**
-   * Set to `true` to pause observing all elements without disconnecting
-   * the observer or losing `elementIntersections`/`elementEntries` state.
-   * Set back to `false` to resume.
-   * @type {boolean}
-   */
-  export let skip = false;
-
-  import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
-
-  const dispatch = createEventDispatcher();
-
-  let prevRootMargin = rootMargin;
-
-  let prevThreshold = threshold;
-
-  /** @type {null | HTMLElement} */
-  let prevRoot = root;
+  /** @type {Props} */
+  let {
+    elements = [],
+    once = false,
+    root = null,
+    rootMargin = "0px",
+    threshold = 0,
+    elementIntersections = $bindable(new Map()),
+    elementEntries = $bindable(new Map()),
+    observer = $bindable(null),
+    skip = false,
+    onobserve,
+    onintersect,
+    children,
+  } = $props();
 
   /** @type {(HTMLElement | null)[]} */
   let prevElements = [];
 
-  let prevSkip = skip;
+  let prevSkip = untrack(() => skip);
 
   const initialize = () => {
     observer = new IntersectionObserver(
@@ -80,10 +47,10 @@
           elementIntersections.set(target, _entry.isIntersecting);
           elementEntries.set(target, _entry);
 
-          dispatch("observe", { entry: _entry, target });
+          onobserve?.({ entry: _entry, target });
 
           if (_entry.isIntersecting) {
-            dispatch("intersect", { entry: _entry, target });
+            onintersect?.({ entry: _entry, target });
             if (once) observer?.unobserve(target);
           }
         }
@@ -96,73 +63,53 @@
     );
   };
 
-  onMount(() => {
+  $effect(() => {
+    prevElements = [];
     initialize();
 
     return () => {
-      if (observer) {
-        observer.disconnect();
-        observer = null;
-      }
+      observer?.disconnect();
+      observer = null;
     };
   });
 
-  afterUpdate(async () => {
-    await tick();
+  $effect(() => {
+    const currentElements = elements;
+    const isSkipped = skip;
+    const activeObserver = observer;
 
-    if (elements.length > 0) {
-      const newElements = elements.filter(
+    if (currentElements.length > 0) {
+      const newElements = currentElements.filter(
         (el) => el && !prevElements.includes(el),
       );
-      if (!skip) {
+
+      if (!isSkipped) {
         for (const el of newElements) {
-          if (el) observer?.observe(el);
+          if (el) activeObserver?.observe(el);
         }
       }
 
       const removedElements = prevElements.filter(
-        (el) => el && !elements.includes(el),
+        (el) => el && !currentElements.includes(el),
       );
+
       for (const el of removedElements) {
-        if (el) observer?.unobserve(el);
+        if (el) activeObserver?.unobserve(el);
       }
 
-      prevElements = [...elements];
+      prevElements = [...currentElements];
     }
 
-    if (skip !== prevSkip) {
-      for (const el of elements.filter((el) => el)) {
+    if (isSkipped !== prevSkip) {
+      for (const el of currentElements) {
         if (!el) continue;
-        if (skip) observer?.unobserve(el);
-        else observer?.observe(el);
+        if (isSkipped) activeObserver?.unobserve(el);
+        else activeObserver?.observe(el);
       }
     }
 
-    if (
-      rootMargin !== prevRootMargin ||
-      threshold !== prevThreshold ||
-      root !== prevRoot
-    ) {
-      observer?.disconnect();
-      prevElements = [];
-      initialize();
-
-      if (!skip) {
-        for (const el of elements.filter((el) => el)) {
-          if (el) observer?.observe(el);
-        }
-      }
-    }
-
-    prevRootMargin = rootMargin;
-    prevThreshold = threshold;
-    prevRoot = root;
-    prevSkip = skip;
+    prevSkip = isSkipped;
   });
 </script>
 
-<slot
-  {observer}
-  {elementIntersections}
-  {elementEntries}
-/>
+{@render children?.({ observer, elementIntersections, elementEntries })}

--- a/src/MultipleIntersectionObserver.svelte.d.ts
+++ b/src/MultipleIntersectionObserver.svelte.d.ts
@@ -1,90 +1,98 @@
-import type { SvelteComponentTyped } from "svelte";
+import type { Component, Snippet } from "svelte";
 
-export default class extends SvelteComponentTyped<
-  {
-    /**
-     * Array of HTML Elements to observe.
-     * Use this for better performance when observing multiple elements.
-     * @default []
-     */
-    elements?: (HTMLElement | null)[];
+export interface MultipleIntersectionObserverProps {
+  /**
+   * Array of HTML Elements to observe.
+   * Use this for better performance when observing multiple elements.
+   * @default []
+   */
+  elements?: (HTMLElement | null)[];
 
-    /**
-     * Set to `true` to unobserve the element
-     * after it intersects the viewport.
-     * @default false
-     */
-    once?: boolean;
+  /**
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
+   * @default false
+   */
+  once?: boolean;
 
-    /**
-     * Specify the containing element.
-     * Defaults to the browser viewport.
-     * @default null
-     */
-    root?: null | HTMLElement;
+  /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
+   * @default null
+   */
+  root?: null | HTMLElement;
 
-    /**
-     * Margin offset of the containing element.
-     * @default "0px"
-     */
-    rootMargin?: string;
+  /**
+   * Margin offset of the containing element.
+   * @default "0px"
+   */
+  rootMargin?: string;
 
-    /**
-     * Percentage of element visibility to trigger an event.
-     * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
-     * @default 0
-     */
-    threshold?: number | number[];
+  /**
+   * Percentage of element visibility to trigger an event.
+   * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
+   * @default 0
+   */
+  threshold?: number | number[];
 
-    /**
-     * Map of element to its intersection state.
-     * @default new Map()
-     */
-    elementIntersections?: Map<HTMLElement | null, boolean>;
+  /**
+   * Map of element to its intersection state.
+   * @default new Map()
+   */
+  elementIntersections?: Map<HTMLElement | null, boolean>;
 
-    /**
-     * Map of element to its latest entry.
-     * @default new Map()
-     */
-    elementEntries?: Map<HTMLElement | null, IntersectionObserverEntry>;
+  /**
+   * Map of element to its latest entry.
+   * @default new Map()
+   */
+  elementEntries?: Map<HTMLElement | null, IntersectionObserverEntry>;
 
-    /**
-     * `IntersectionObserver` instance.
-     * @default null
-     */
-    observer?: null | IntersectionObserver;
+  /**
+   * `IntersectionObserver` instance.
+   * @default null
+   */
+  observer?: null | IntersectionObserver;
 
-    /**
-     * Set to `true` to pause observing all elements without disconnecting
-     * the observer or losing `elementIntersections`/`elementEntries` state.
-     * Set back to `false` to resume.
-     * @default false
-     */
-    skip?: boolean;
-  },
-  {
-    /**
-     * Dispatched when an element is first observed
-     * and also whenever an intersection event occurs.
-     */
-    observe: CustomEvent<{
-      entry: IntersectionObserverEntry;
-      target: HTMLElement;
-    }>;
+  /**
+   * Set to `true` to pause observing all elements without disconnecting
+   * the observer or losing `elementIntersections`/`elementEntries` state.
+   * Set back to `false` to resume.
+   * @default false
+   */
+  skip?: boolean;
 
-    /**
-     * Dispatched only when an element is intersecting the viewport.
-     */
-    intersect: CustomEvent<{
-      entry: IntersectionObserverEntry & { isIntersecting: true };
-      target: HTMLElement;
-    }>;
-  },
-  {
-    default: {
-      observer: IntersectionObserver;
-      elementIntersections: Map<HTMLElement | null, boolean>;
-      elementEntries: Map<HTMLElement | null, IntersectionObserverEntry>;
-    };
-  }
-> {}
+  /**
+   * Called when an element is first observed
+   * and also whenever an intersection event occurs.
+   */
+  onobserve?: (detail: {
+    entry: IntersectionObserverEntry;
+    target: HTMLElement;
+  }) => void;
+
+  /**
+   * Called only when an element is intersecting the viewport.
+   */
+  onintersect?: (detail: {
+    entry: IntersectionObserverEntry & { isIntersecting: true };
+    target: HTMLElement;
+  }) => void;
+
+  children?: Snippet<
+    [
+      {
+        observer: null | IntersectionObserver;
+        elementIntersections: Map<HTMLElement | null, boolean>;
+        elementEntries: Map<HTMLElement | null, IntersectionObserverEntry>;
+      },
+    ]
+  >;
+}
+
+declare const MultipleIntersectionObserverComponent: Component<
+  MultipleIntersectionObserverProps,
+  Record<string, never>,
+  "elementIntersections" | "elementEntries" | "observer"
+>;
+
+export default MultipleIntersectionObserverComponent;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
 export { default } from "./IntersectionObserver.svelte";
-export type { IntersectActionOptions } from "./intersect.js";
-export { intersect } from "./intersect.js";
+export type { IntersectActionOptions } from "./intersect.svelte.js";
+export { intersect } from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export { default } from "./IntersectionObserver.svelte";
-export { intersect } from "./intersect.js";
+export { intersect } from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -39,14 +39,14 @@ export interface IntersectActionOptions {
 /**
  * Svelte action that observes the element with the Intersection Observer API.
  * Dispatches `observe` (on every change) and `intersect` (on entering the
- * viewport) `CustomEvent`s on the element — listen with `on:observe`/`on:intersect`.
+ * viewport) `CustomEvent`s on the element — listen with `onobserve`/`onintersect`.
  */
 export const intersect: Action<
   HTMLElement,
   IntersectActionOptions | undefined,
   {
-    "on:observe"?: (event: CustomEvent<IntersectionObserverEntry>) => void;
-    "on:intersect"?: (
+    onobserve?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+    onintersect?: (
       event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>,
     ) => void;
   }

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -1,9 +1,9 @@
 /**
  * Svelte action that observes `node` with the Intersection Observer API.
  * Dispatches `observe` (on every change) and `intersect` (on entering the
- * viewport) `CustomEvent`s on `node` — listen with `on:observe`/`on:intersect`.
+ * viewport) `CustomEvent`s on `node` — listen with `onobserve`/`onintersect`.
  * @param {HTMLElement} node
- * @param {import("./intersect.d.ts").IntersectActionOptions} [options]
+ * @param {import("./intersect.svelte.d.ts").IntersectActionOptions} [options]
  */
 export function intersect(node, options = {}) {
   let {
@@ -36,7 +36,7 @@ export function intersect(node, options = {}) {
   if (!skip) observer.observe(node);
 
   return {
-    /** @param {import("./intersect.d.ts").IntersectActionOptions} [newOptions] */
+    /** @param {import("./intersect.svelte.d.ts").IntersectActionOptions} [newOptions] */
     update(newOptions = {}) {
       once = newOptions.once ?? false;
 

--- a/tests/IntersectionObserver.test.svelte
+++ b/tests/IntersectionObserver.test.svelte
@@ -6,7 +6,7 @@
   import type { ComponentProps } from "svelte";
   import SvelteIntersectionObserver from "svelte-intersection-observer";
 
-  type Props = ComponentProps<SvelteIntersectionObserver>;
+  type Props = ComponentProps<typeof SvelteIntersectionObserver>;
 
   let intersecting: Props["intersecting"] = false;
   let entry: Props["entry"];
@@ -22,20 +22,19 @@
   {skip}
   bind:observer
   bind:intersecting
-  on:observe={(e) => {
-    e.detail.intersectionRect; // DOMRectReadOnly
-    e.detail.isIntersecting; // boolean
+  onobserve={(entry) => {
+    entry.intersectionRect; // DOMRectReadOnly
+    entry.isIntersecting; // boolean
   }}
-  on:intersect={(e) => {
-    e.detail.isIntersecting; // true
+  onintersect={(entry) => {
+    entry.isIntersecting; // true
   }}
-  let:entry
-  let:intersecting
-  let:observer
 >
-  <div bind:this={element}>
-    {intersecting ? "Element is in view" : "Element is not in view"}
-    {entry?.boundingClientRect}
-    {observer}
-  </div>
+  {#snippet children({ entry, intersecting, observer })}
+    <div bind:this={element}>
+      {intersecting ? "Element is in view" : "Element is not in view"}
+      {entry?.boundingClientRect}
+      {observer}
+    </div>
+  {/snippet}
 </SvelteIntersectionObserver>

--- a/tests/MultipleIntersectionObserver.test.svelte
+++ b/tests/MultipleIntersectionObserver.test.svelte
@@ -6,7 +6,7 @@
   import type { ComponentProps } from "svelte";
   import { MultipleIntersectionObserver } from "svelte-intersection-observer";
 
-  type Props = ComponentProps<MultipleIntersectionObserver>;
+  type Props = ComponentProps<typeof MultipleIntersectionObserver>;
 
   let elements: Props["elements"] = [];
   let elementIntersections: Props["elementIntersections"] = new Map();
@@ -26,26 +26,25 @@
   bind:observer
   bind:elementIntersections
   bind:elementEntries
-  on:observe={(e) => {
-    e.detail.target; // HTMLElement
-    e.detail.entry.intersectionRect; // DOMRectReadOnly
-    e.detail.entry.isIntersecting; // boolean
+  onobserve={(detail) => {
+    detail.target; // HTMLElement
+    detail.entry.intersectionRect; // DOMRectReadOnly
+    detail.entry.isIntersecting; // boolean
   }}
-  on:intersect={(e) => {
-    e.detail.target; // HTMLElement
-    e.detail.entry.isIntersecting; // true
+  onintersect={(detail) => {
+    detail.target; // HTMLElement
+    detail.entry.isIntersecting; // true
   }}
-  let:elementIntersections
-  let:elementEntries
-  let:observer
 >
-  <div bind:this={ref1}>
-    {elementIntersections.get(ref1) ? "visible" : "not visible"}
-    {elementEntries.get(ref1)?.boundingClientRect}
-  </div>
-  <div bind:this={ref2}>
-    {elementIntersections.get(ref2) ? "visible" : "not visible"}
-    {elementEntries.get(ref2)?.boundingClientRect}
-  </div>
-  {observer}
+  {#snippet children({ elementIntersections, elementEntries, observer })}
+    <div bind:this={ref1}>
+      {elementIntersections.get(ref1) ? "visible" : "not visible"}
+      {elementEntries.get(ref1)?.boundingClientRect}
+    </div>
+    <div bind:this={ref2}>
+      {elementIntersections.get(ref2) ? "visible" : "not visible"}
+      {elementEntries.get(ref2)?.boundingClientRect}
+    </div>
+    {observer}
+  {/snippet}
 </MultipleIntersectionObserver>

--- a/tests/e2e/fixtures/ActionFixture.svelte
+++ b/tests/e2e/fixtures/ActionFixture.svelte
@@ -12,8 +12,8 @@
 
 <div
   use:intersect={{ once: true }}
-  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
-  on:intersect={() => (intersectCount += 1)}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
+  onintersect={() => (intersectCount += 1)}
 >
   Hello world
 </div>

--- a/tests/e2e/fixtures/ActionRootMarginChangeFixture.svelte
+++ b/tests/e2e/fixtures/ActionRootMarginChangeFixture.svelte
@@ -9,7 +9,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="shrink-root-margin"
-    on:click={() => (rootMargin = "-200px")}
+    onclick={() => (rootMargin = "-200px")}
   >
     Shrink root margin
   </button>
@@ -17,7 +17,7 @@
 
 <div
   use:intersect={{ rootMargin }}
-  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
 >
   Hello world
 </div>

--- a/tests/e2e/fixtures/ActionSkipFixture.svelte
+++ b/tests/e2e/fixtures/ActionSkipFixture.svelte
@@ -9,7 +9,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="toggle-skip"
-    on:click={() => (skip = !skip)}
+    onclick={() => (skip = !skip)}
   >
     {skip ? "Resume" : "Pause"}
   </button>
@@ -17,7 +17,7 @@
 
 <div
   use:intersect={{ skip }}
-  on:observe={(e) => (intersecting = e.detail.isIntersecting)}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
 >
   Hello world
 </div>

--- a/tests/e2e/fixtures/EachBindingFixture.svelte
+++ b/tests/e2e/fixtures/EachBindingFixture.svelte
@@ -5,17 +5,17 @@
     {
       id: "one",
       node: undefined as undefined | HTMLElement,
-      intersecting: undefined as undefined | boolean,
+      intersecting: false,
     },
     {
       id: "two",
       node: undefined as undefined | HTMLElement,
-      intersecting: undefined as undefined | boolean,
+      intersecting: false,
     },
     {
       id: "three",
       node: undefined as undefined | HTMLElement,
-      intersecting: undefined as undefined | boolean,
+      intersecting: false,
     },
   ];
 </script>

--- a/tests/e2e/fixtures/ElementChangeFixture.svelte
+++ b/tests/e2e/fixtures/ElementChangeFixture.svelte
@@ -10,7 +10,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="switch"
-    on:click={() => (element = elementB)}
+    onclick={() => (element = elementB)}
   >
     Switch
   </button>

--- a/tests/e2e/fixtures/MultipleBasicFixture.svelte
+++ b/tests/e2e/fixtures/MultipleBasicFixture.svelte
@@ -7,37 +7,36 @@
   $: elements = [ref1, ref2];
 </script>
 
-<MultipleIntersectionObserver
-  {elements}
-  let:elementIntersections
->
-  <header>
-    <div
-      data-testid="item-1-indicator"
-      class:intersecting={elementIntersections.get(ref1)}
-    >
-      Item 1: {elementIntersections.get(ref1) ? "✓" : "✗"}
-    </div>
-    <div
-      data-testid="item-2-indicator"
-      class:intersecting={elementIntersections.get(ref2)}
-    >
-      Item 2: {elementIntersections.get(ref2) ? "✓" : "✗"}
-    </div>
-  </header>
+<MultipleIntersectionObserver {elements}>
+  {#snippet children({ elementIntersections })}
+    <header>
+      <div
+        data-testid="item-1-indicator"
+        class:intersecting={elementIntersections.get(ref1)}
+      >
+        Item 1: {elementIntersections.get(ref1) ? "✓" : "✗"}
+      </div>
+      <div
+        data-testid="item-2-indicator"
+        class:intersecting={elementIntersections.get(ref2)}
+      >
+        Item 2: {elementIntersections.get(ref2) ? "✓" : "✗"}
+      </div>
+    </header>
 
-  <div
-    bind:this={ref1}
-    data-testid="item-1"
-  >
-    Item 1
-  </div>
-  <div
-    bind:this={ref2}
-    data-testid="item-2"
-  >
-    Item 2
-  </div>
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+    >
+      Item 2
+    </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleBindingFixture.svelte
+++ b/tests/e2e/fixtures/MultipleBindingFixture.svelte
@@ -14,7 +14,6 @@
 <MultipleIntersectionObserver
   {elements}
   bind:elementIntersections
-  let:elementIntersections
 >
   <header
     class:intersecting={anyItemVisible}

--- a/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
@@ -9,47 +9,46 @@
   $: elements = [includeItem1 ? ref1 : null, includeItem2 ? ref2 : null];
 </script>
 
-<MultipleIntersectionObserver
-  {elements}
-  let:elementIntersections
->
-  <header>
-    <button
-      data-testid="add-item-2"
-      on:click={() => (includeItem2 = true)}
-    >
-      Add item 2
-    </button>
-    <button
-      data-testid="remove-item-1"
-      on:click={() => (includeItem1 = false)}
-    >
-      Remove item 1
-    </button>
-    <p data-testid="item-1-status">
-      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-2-status">
-      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
-    </p>
-  </header>
+<MultipleIntersectionObserver {elements}>
+  {#snippet children({ elementIntersections })}
+    <header>
+      <button
+        data-testid="add-item-2"
+        onclick={() => (includeItem2 = true)}
+      >
+        Add item 2
+      </button>
+      <button
+        data-testid="remove-item-1"
+        onclick={() => (includeItem1 = false)}
+      >
+        Remove item 1
+      </button>
+      <p data-testid="item-1-status">
+        {`Item 1 ${elementIntersections.get(ref1) ? "is visible" : "is not visible"}`}
+      </p>
+      <p data-testid="item-2-status">
+        {`Item 2 ${elementIntersections.get(ref2) ? "is visible" : "is not visible"}`}
+      </p>
+    </header>
 
-  <div style="display: flex; margin-top: calc(100vh + 1px);">
-    <div
-      bind:this={ref1}
-      data-testid="item-1"
-      style="height: 38vh; width: 50%; background-color: #376462; color: #fff;"
-    >
-      Item 1
+    <div style="display: flex; margin-top: calc(100vh + 1px);">
+      <div
+        bind:this={ref1}
+        data-testid="item-1"
+        style="height: 38vh; width: 50%; background-color: #376462; color: #fff;"
+      >
+        Item 1
+      </div>
+      <div
+        bind:this={ref2}
+        data-testid="item-2"
+        style="height: 38vh; width: 50%; background-color: #2ecc71; color: #fff;"
+      >
+        Item 2
+      </div>
     </div>
-    <div
-      bind:this={ref2}
-      data-testid="item-2"
-      style="height: 38vh; width: 50%; background-color: #2ecc71; color: #fff;"
-    >
-      Item 2
-    </div>
-  </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleFixture.svelte
+++ b/tests/e2e/fixtures/MultipleFixture.svelte
@@ -8,41 +8,42 @@
   $: elements = [ref1, ref2, ref3];
 </script>
 
-<MultipleIntersectionObserver
-  {elements}
-  let:elementIntersections
->
-  <header>
-    {#each elements as el, index}
-      {@const visible = elementIntersections.get(el)}
-      {#if visible}
-        <p data-testid="item-{index + 1}-status">Item {index + 1} is visible</p>
-      {:else}
-        <p data-testid="item-{index + 1}-status">
-          Item {index + 1} is not visible
-        </p>
-      {/if}
-    {/each}
-  </header>
+<MultipleIntersectionObserver {elements}>
+  {#snippet children({ elementIntersections })}
+    <header>
+      {#each elements as el, index}
+        {@const visible = elementIntersections.get(el)}
+        {#if visible}
+          <p data-testid="item-{index + 1}-status">
+            Item {index + 1} is visible
+          </p>
+        {:else}
+          <p data-testid="item-{index + 1}-status">
+            Item {index + 1} is not visible
+          </p>
+        {/if}
+      {/each}
+    </header>
 
-  <div
-    bind:this={ref1}
-    data-testid="item-1"
-  >
-    Item 1
-  </div>
-  <div
-    bind:this={ref2}
-    data-testid="item-2"
-  >
-    Item 2
-  </div>
-  <div
-    bind:this={ref3}
-    data-testid="item-3"
-  >
-    Item 3
-  </div>
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+    >
+      Item 2
+    </div>
+    <div
+      bind:this={ref3}
+      data-testid="item-3"
+    >
+      Item 3
+    </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleOnceFixture.svelte
+++ b/tests/e2e/fixtures/MultipleOnceFixture.svelte
@@ -12,35 +12,40 @@
 <MultipleIntersectionObserver
   {elements}
   once
-  let:elementIntersections
-  on:intersect={(e) => {
-    if (e.detail.target === ref1) intersectCount1 += 1;
-    if (e.detail.target === ref2) intersectCount2 += 1;
+  onintersect={(detail) => {
+    if (detail.target === ref1) intersectCount1 += 1;
+    if (detail.target === ref2) intersectCount2 += 1;
   }}
 >
-  <header>
-    <p data-testid="item-1-status">
-      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-2-status">
-      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-1-count">Item 1 intersect count: {intersectCount1}</p>
-    <p data-testid="item-2-count">Item 2 intersect count: {intersectCount2}</p>
-  </header>
+  {#snippet children({ elementIntersections })}
+    <header>
+      <p data-testid="item-1-status">
+        {`Item 1 ${elementIntersections.get(ref1) ? "is visible" : "is not visible"}`}
+      </p>
+      <p data-testid="item-2-status">
+        {`Item 2 ${elementIntersections.get(ref2) ? "is visible" : "is not visible"}`}
+      </p>
+      <p data-testid="item-1-count">
+        Item 1 intersect count: {intersectCount1}
+      </p>
+      <p data-testid="item-2-count">
+        Item 2 intersect count: {intersectCount2}
+      </p>
+    </header>
 
-  <div
-    bind:this={ref1}
-    data-testid="item-1"
-  >
-    Item 1
-  </div>
-  <div
-    bind:this={ref2}
-    data-testid="item-2"
-  >
-    Item 2
-  </div>
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+    >
+      Item 2
+    </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleRootMarginChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleRootMarginChangeFixture.svelte
@@ -10,19 +10,20 @@
 <MultipleIntersectionObserver
   {elements}
   {rootMargin}
-  let:elementIntersections
 >
-  <header>
-    {elementIntersections.get(ref1) ? "Element is in view" : "Element is not in view"}
-    <button
-      data-testid="shrink-root-margin"
-      on:click={() => (rootMargin = "-200px")}
-    >
-      Shrink root margin
-    </button>
-  </header>
+  {#snippet children({ elementIntersections })}
+    <header>
+      {elementIntersections.get(ref1) ? "Element is in view" : "Element is not in view"}
+      <button
+        data-testid="shrink-root-margin"
+        onclick={() => (rootMargin = "-200px")}
+      >
+        Shrink root margin
+      </button>
+    </header>
 
-  <div bind:this={ref1}>Hello world</div>
+    <div bind:this={ref1}>Hello world</div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleSkipFixture.svelte
+++ b/tests/e2e/fixtures/MultipleSkipFixture.svelte
@@ -11,35 +11,36 @@
 <MultipleIntersectionObserver
   {elements}
   {skip}
-  let:elementIntersections
 >
-  <header>
-    <p data-testid="item-1-status">
-      Item 1 {elementIntersections.get(ref1) ? "is visible" : "is not visible"}
-    </p>
-    <p data-testid="item-2-status">
-      Item 2 {elementIntersections.get(ref2) ? "is visible" : "is not visible"}
-    </p>
-    <button
-      data-testid="toggle-skip"
-      on:click={() => (skip = !skip)}
-    >
-      {skip ? "Resume" : "Pause"}
-    </button>
-  </header>
+  {#snippet children({ elementIntersections })}
+    <header>
+      <p data-testid="item-1-status">
+        {`Item 1 ${elementIntersections.get(ref1) ? "is visible" : "is not visible"}`}
+      </p>
+      <p data-testid="item-2-status">
+        {`Item 2 ${elementIntersections.get(ref2) ? "is visible" : "is not visible"}`}
+      </p>
+      <button
+        data-testid="toggle-skip"
+        onclick={() => (skip = !skip)}
+      >
+        {skip ? "Resume" : "Pause"}
+      </button>
+    </header>
 
-  <div
-    bind:this={ref1}
-    data-testid="item-1"
-  >
-    Item 1
-  </div>
-  <div
-    bind:this={ref2}
-    data-testid="item-2"
-  >
-    Item 2
-  </div>
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+    >
+      Item 2
+    </div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/MultipleThresholdFixture.svelte
+++ b/tests/e2e/fixtures/MultipleThresholdFixture.svelte
@@ -9,15 +9,16 @@
 <MultipleIntersectionObserver
   {elements}
   threshold={0.5}
-  let:elementIntersections
 >
-  <header>
-    {elementIntersections.get(ref1)
-      ? "Element is in view"
-      : "Element is not in view"}
-  </header>
+  {#snippet children({ elementIntersections })}
+    <header>
+      {elementIntersections.get(ref1)
+        ? "Element is in view"
+        : "Element is not in view"}
+    </header>
 
-  <div bind:this={ref1}>Hello world</div>
+    <div bind:this={ref1}>Hello world</div>
+  {/snippet}
 </MultipleIntersectionObserver>
 
 <style>

--- a/tests/e2e/fixtures/OnceFixture.svelte
+++ b/tests/e2e/fixtures/OnceFixture.svelte
@@ -12,7 +12,7 @@
   <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
   <button
     data-testid="unrelated-button"
-    on:click={() => (unrelated += 1)}
+    onclick={() => (unrelated += 1)}
   >
     Unrelated: {unrelated}
   </button>
@@ -22,7 +22,7 @@
   {element}
   bind:intersecting
   once
-  on:intersect={() => (intersectCount += 1)}
+  onintersect={() => (intersectCount += 1)}
 >
   <div bind:this={element}>Hello world</div>
 </IntersectionObserver>

--- a/tests/e2e/fixtures/RootMarginChangeFixture.svelte
+++ b/tests/e2e/fixtures/RootMarginChangeFixture.svelte
@@ -10,7 +10,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="shrink-root-margin"
-    on:click={() => (rootMargin = "-200px")}
+    onclick={() => (rootMargin = "-200px")}
   >
     Shrink root margin
   </button>

--- a/tests/e2e/fixtures/SkipFixture.svelte
+++ b/tests/e2e/fixtures/SkipFixture.svelte
@@ -10,7 +10,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="toggle-skip"
-    on:click={() => (skip = !skip)}
+    onclick={() => (skip = !skip)}
   >
     {skip ? "Resume" : "Pause"}
   </button>

--- a/tests/e2e/fixtures/ThresholdChangeFixture.svelte
+++ b/tests/e2e/fixtures/ThresholdChangeFixture.svelte
@@ -10,7 +10,7 @@
   {intersecting ? "Element is in view" : "Element is not in view"}
   <button
     data-testid="raise-threshold"
-    on:click={() => (threshold = 0.99)}
+    onclick={() => (threshold = 0.99)}
   >
     Raise threshold
   </button>

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -18,11 +18,11 @@
 
 <div
   use:intersect={options}
-  on:observe={(e) => {
+  onobserve={(e) => {
     e.detail.intersectionRect; // DOMRectReadOnly
     e.detail.isIntersecting; // boolean
   }}
-  on:intersect={(e) => {
+  onintersect={(e) => {
     e.detail.isIntersecting; // true
   }}
 >


### PR DESCRIPTION
Closes #78 

- Rewrite `IntersectionObserver` and `MultipleIntersectionObserver` to use Svelte 5 runes (`$props()`, `$bindable()`, `$effect()`) instead of `export let`/`createEventDispatcher`/`onMount`/`afterUpdate`.
- Replace the default `<slot>` with a `children` snippet — consumers destructure `{ intersecting, entry, observer }` (or `{ elementIntersections, elementEntries, observer }`) via `{#snippet children(...)}`.
- Replace dispatched `observe`/`intersect` events with `onobserve`/`onintersect` callback props, called directly with the `IntersectionObserverEntry` (or `{ entry, target }`) instead of a `CustomEvent`.
- `use:intersect` action is unchanged at runtime (still dispatches native `CustomEvent`s) but is now listened to via `onobserve`/`onintersect` attributes instead of the removed `on:` directive.
- Rename `src/intersect.js`/`src/intersect.d.ts` to `src/intersect.svelte.js`/`src/intersect.svelte.d.ts`.
- Update all e2e fixtures, `svelte-check` type tests, and README examples to the new API.
- Fix a variable-name collision across two README demos (`node`/`intersecting` reused in separate code fences) that caused one live demo to silently observe the wrong DOM element in the docs preview.

This is a breaking change targeted at a v2 release; `svelte@^5` in runes mode is now required.
