### PR TITLE
feat: add intersectAttachment as an attachment counterpart to the intersect action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 
 Use it to lazy-load images, trigger scroll animations, implement infinite scroll, autoplay video when visible, track ad or analytics impressions, or detect when a user has scrolled to the end of a list.
 
-This library is zero-dependency and offers three ways to observe elements: the `IntersectionObserver` component for a single element, the `MultipleIntersectionObserver` component for observing many elements with one shared observer (better performance than one observer per element), and the `intersect` action for observing an element directly with `use:`.
+This library is zero-dependency and offers several ways to observe elements:
+
+- `IntersectionObserver`: component for a single element
+- `MultipleIntersectionObserver`: component for observing many elements (shared observer, better performance)
+- `intersect`: action for observing an element directly with `use:`
+- `intersectAttachment`: attachment for observing an element directly with `{@attach}` (Svelte 5.29+)
 
 Try it in the [Svelte REPL](https://svelte.dev/repl/8cd2327a580c4f429c71f7df999bd51d).
 
@@ -263,6 +268,37 @@ As an alternative to the `IntersectionObserver` component, use the `intersect` a
 
 Options passed to `use:intersect` are reactive: updating `root`, `rootMargin`, or `threshold` re-initializes the underlying observer. Updating `skip` toggles observing on the existing observer without re-initializing it.
 
+### `intersectAttachment` attachment
+
+As of Svelte 5.29, [attachments](https://svelte.dev/docs/svelte/svelte-attachments) are the preferred replacement for actions. `intersectAttachment` wraps the `intersect` action with `svelte/attachments`'s `fromAction`, reusing the same observer logic but plugging into `{@attach ...}` instead of `use:`.
+
+Attachments have a few architectural advantages over actions:
+
+- No separate `update()` lifecycle method; they rerun reactively like a `$effect`
+- Just plain functions, so they're easier to compose and generate dynamically
+- Can be forwarded through components as ordinary props, unlike actions
+
+```svelte
+<script>
+  import { intersectAttachment } from "svelte-intersection-observer";
+
+  let attachmentIntersecting = $state(false);
+</script>
+
+<header class:intersecting={attachmentIntersecting}>
+  {attachmentIntersecting ? "Element is in view" : "Element is not in view"}
+</header>
+
+<div
+  {@attach intersectAttachment(() => ({ once: true }))}
+  onobserve={(e) => (attachmentIntersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+```
+
+**Note**: unlike `use:intersect`, which takes the options object directly, `intersectAttachment` takes a function that _returns_ the options object (this is how `fromAction` tracks reactive dependencies). `intersect` remains fully supported; use whichever fits your codebase.
+
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements with a single shared observer instead of instantiating a new one for every element.
@@ -417,7 +453,9 @@ Both callbacks are called with:
 | elementIntersections | `Map<HTMLElement \| null, boolean>`                                                                                                     |
 | elementEntries       | `Map<HTMLElement \| null,` [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)`>` |
 
-### `intersect` action
+### `intersect` action / `intersectAttachment` attachment
+
+`intersectAttachment` is a thin wrapper around the `intersect` action (see [above](#intersectattachment-attachment)), so both share the same options and dispatched events.
 
 #### Options
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
 export { default } from "./IntersectionObserver.svelte";
 export type { IntersectActionOptions } from "./intersect.svelte.js";
-export { intersect } from "./intersect.svelte.js";
+export { intersect, intersectAttachment } from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export { default } from "./IntersectionObserver.svelte";
-export { intersect } from "./intersect.svelte.js";
+export { intersect, intersectAttachment } from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -1,4 +1,5 @@
 import type { Action } from "svelte/action";
+import type { Attachment } from "svelte/attachments";
 
 export interface IntersectActionOptions {
   /**
@@ -51,3 +52,11 @@ export const intersect: Action<
     ) => void;
   }
 >;
+
+/**
+ * Svelte attachment that observes the element with the Intersection Observer
+ * API. Equivalent to `intersect`, for use with `{@attach}` instead of `use:`.
+ */
+export function intersectAttachment(
+  getOptions?: () => IntersectActionOptions,
+): Attachment<HTMLElement>;

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -1,3 +1,5 @@
+import { fromAction } from "svelte/attachments";
+
 /**
  * Svelte action that observes `node` with the Intersection Observer API.
  * Dispatches `observe` (on every change) and `intersect` (on entering the
@@ -66,4 +68,14 @@ export function intersect(node, options = {}) {
       observer.disconnect();
     },
   };
+}
+
+/**
+ * Svelte attachment that observes the element with the Intersection Observer
+ * API. Equivalent to the `intersect` action, for use with `{@attach}` instead
+ * of `use:`. Wraps `intersect` via `svelte/attachments`'s `fromAction`.
+ * @param {() => import("./intersect.svelte.d.ts").IntersectActionOptions} [getOptions]
+ */
+export function intersectAttachment(getOptions = () => ({})) {
+  return fromAction(intersect, getOptions);
 }

--- a/tests/e2e/fixtures/AttachmentFixture.svelte
+++ b/tests/e2e/fixtures/AttachmentFixture.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
+  import { intersectAttachment } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let intersectCount = 0;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
+</header>
+
+<div
+  {@attach intersectAttachment(() => ({ once: true }))}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
+  onintersect={() => (intersectCount += 1)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/AttachmentRootMarginChangeFixture.svelte
+++ b/tests/e2e/fixtures/AttachmentRootMarginChangeFixture.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
+  import { intersectAttachment } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let rootMargin = "0px";
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="shrink-root-margin"
+    onclick={() => (rootMargin = "-200px")}
+  >
+    Shrink root margin
+  </button>
+</header>
+
+<div
+  {@attach intersectAttachment(() => ({ rootMargin }))}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/AttachmentSkipFixture.svelte
+++ b/tests/e2e/fixtures/AttachmentSkipFixture.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  // biome-ignore lint/correctness/noUnusedImports: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
+  import { intersectAttachment } from "svelte-intersection-observer";
+
+  let intersecting = false;
+  let skip = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="toggle-skip"
+    onclick={() => (skip = !skip)}
+  >
+    {skip ? "Resume" : "Pause"}
+  </button>
+</header>
+
+<div
+  {@attach intersectAttachment(() => ({ skip }))}
+  onobserve={(e) => (intersecting = e.detail.isIntersecting)}
+>
+  Hello world
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/attachment-root-margin-change.html
+++ b/tests/e2e/fixtures/attachment-root-margin-change.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Attachment Root Margin Change Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./attachment-root-margin-change.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/attachment-root-margin-change.ts
+++ b/tests/e2e/fixtures/attachment-root-margin-change.ts
@@ -1,0 +1,4 @@
+import AttachmentRootMarginChangeFixture from "./AttachmentRootMarginChangeFixture.svelte";
+import { mount } from "./mount";
+
+mount(AttachmentRootMarginChangeFixture);

--- a/tests/e2e/fixtures/attachment-skip.html
+++ b/tests/e2e/fixtures/attachment-skip.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Attachment Skip Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./attachment-skip.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/attachment-skip.ts
+++ b/tests/e2e/fixtures/attachment-skip.ts
@@ -1,0 +1,4 @@
+import AttachmentSkipFixture from "./AttachmentSkipFixture.svelte";
+import { mount } from "./mount";
+
+mount(AttachmentSkipFixture);

--- a/tests/e2e/fixtures/attachment.html
+++ b/tests/e2e/fixtures/attachment.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Attachment Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./attachment.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/attachment.ts
+++ b/tests/e2e/fixtures/attachment.ts
@@ -1,0 +1,4 @@
+import AttachmentFixture from "./AttachmentFixture.svelte";
+import { mount } from "./mount";
+
+mount(AttachmentFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -202,6 +202,62 @@ test("Action - reinitializes the observer when the parameter changes at runtime"
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Attachment - skip pauses observing without losing state, resumes on toggle", async ({
+  page,
+}) => {
+  await page.goto("/attachment-skip.html");
+  const header = page.locator("header");
+
+  await expect(header).toHaveText(/Element is not in view/);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("toggle-skip").click();
+  await expect(header).toHaveText(/Element is not in view/);
+});
+
+test("Attachment - {@attach intersectAttachment} dispatches observe/intersect events and honors once", async ({
+  page,
+}) => {
+  await page.goto("/attachment.html");
+  const app = page.locator("#app");
+
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 0/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+  await expect(app).toHaveText(/Hello world/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+});
+
+test("Attachment - reinitializes the observer when the parameter changes at runtime", async ({
+  page,
+}) => {
+  await page.goto("/attachment-root-margin-change.html");
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+
+  await page.getByTestId("shrink-root-margin").click();
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+});
+
 test("Multiple elements - reinitializes the observer when root margin changes at runtime", async ({
   page,
 }) => {

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -6,6 +6,8 @@
   import {
     type IntersectActionOptions,
     intersect,
+    // biome-ignore lint/correctness/noUnusedImports: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
+    intersectAttachment,
   } from "svelte-intersection-observer";
 
   let options: IntersectActionOptions = {
@@ -18,6 +20,19 @@
 
 <div
   use:intersect={options}
+  onobserve={(e) => {
+    e.detail.intersectionRect; // DOMRectReadOnly
+    e.detail.isIntersecting; // boolean
+  }}
+  onintersect={(e) => {
+    e.detail.isIntersecting; // true
+  }}
+>
+  Hello world
+</div>
+
+<div
+  {@attach intersectAttachment(() => options)}
   onobserve={(e) => {
     e.detail.intersectionRect; // DOMRectReadOnly
     e.detail.isIntersecting; // boolean


### PR DESCRIPTION
## Summary
- Add `intersectAttachment`, a Svelte attachment counterpart to the existing `intersect` action, built on top of `svelte/attachments`'s `fromAction` so it reuses the same observer logic instead of duplicating it.
- Keep the `intersect` action unchanged and fully supported; both are exported from the package.
- Document `intersectAttachment` in the README (usage example, architectural advantages of attachments over actions, updated API reference, bullet-point overview of the library's observation APIs).

## Test plan
- [x] `bun run test:types` (svelte-check)
- [x] `bunx biome check .`
- [x] `bun run build` (docs site build)
- [x] `bun run test:e2e` (26/26 Playwright tests pass, including new attachment fixtures covering basic/once, skip, and root-margin reinit)