### PR TITLE
fix: type onobserve/onintersect for intersectAttachment usage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@playwright/test": "^1.61.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/bun": "^1.3.14",
-        "@typescript/native-preview": "^7.0.0-dev.20260703.1",
         "svelte": "5.56.4",
         "svelte-check": "^4.7.1",
         "svelte-readme": "^4.2.0",
@@ -107,22 +106,6 @@
     "@types/node": ["@types/node@22.13.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
-
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260703.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260703.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260703.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260703.1" }, "bin": { "tsgo": "bin/tsgo" } }, "sha512-qyEHkEeRWCSGLa6a8oArnMPdn3Vcl1AZj8YHLO7lK0VjEEF/YJfz1FvxmpEeuhy0ZDfvJ7GtgXbvbjcU3zpPjQ=="],
-
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260703.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EwJEd6hfaHrrbSLat6+xX8fZiAvG+/Ae1gqvJEayTNdDbkrZxmeLS23YdjUmDMIOKI2wa7zXQDid8WtrvDfMTQ=="],
-
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260703.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-tcS3gpivMq+BAiaupFqM5vuERykogJlfD4CjoxkSCksmmsKgWV96S2U/LjrKgll8R6/OEkg2VL2ycRG9+tIuHw=="],
-
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "arm" }, "sha512-nluwnKcdGo6laWWYtWF3zFUDfi7nNrcD5S/T5382fVmtKmNqIdzFm9ANgSSGAavuzfdu9YJLaVWpx72Oe40AEQ=="],
-
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-m8IJTOneLXRtq6prLz8uuhp463kEt+AHV5Ceqp7G0o3eAvbKP059OwzK6WXCS5J0B3ZxX+BwBf9wDXSNidWJCw=="],
-
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260703.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5ga94rso68kaxJUzaufDVhka1zPaSbPgNXaemQO8faPW0crvRIkbv0g8bpG4pdWMV0tTylmluDles4ZcAzOprg=="],
-
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260703.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YeRqOUuSyhbtryBSUE073OLpReIQXWJVyjP45gPLJ+0KAGvkd1VFz2FY1JEo++LyHoqXsGD2+qvdPpnTfSAIJg=="],
-
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260703.1", "", { "os": "win32", "cpu": "x64" }, "sha512-WYNcbTaxCPgiDLrL2aPJ3BJA05nJU8DK0fUFGkGAER0oM+KcJcQUBeUkXg/7A4HBTNYcj7zIxqNgkJU1TRa/Kw=="],
 
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "package": "bun scripts/npm-package.ts",
-    "test:types": "svelte-check --workspace tests --tsgo",
+    "test:types": "svelte-check --workspace tests",
     "test:e2e": "playwright test",
     "lint": "biome check --write .",
     "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched ."
@@ -21,7 +21,6 @@
     "@playwright/test": "^1.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/bun": "^1.3.14",
-    "@typescript/native-preview": "^7.0.0-dev.20260703.1",
     "svelte": "5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-readme": "^4.2.0",

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -48,7 +48,11 @@
           onobserve?.(_entry);
 
           if (_entry.isIntersecting) {
-            onintersect?.(_entry);
+            onintersect?.(
+              /** @type {IntersectionObserverEntry & { isIntersecting: true }} */ (
+                _entry
+              ),
+            );
 
             if (element && once) observer?.unobserve(element);
           }

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -50,7 +50,13 @@
           onobserve?.({ entry: _entry, target });
 
           if (_entry.isIntersecting) {
-            onintersect?.({ entry: _entry, target });
+            onintersect?.({
+              entry:
+                /** @type {IntersectionObserverEntry & { isIntersecting: true }} */ (
+                  _entry
+                ),
+              target,
+            });
             if (once) observer?.unobserve(target);
           }
         }

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -60,3 +60,16 @@ export const intersect: Action<
 export function intersectAttachment(
   getOptions?: () => IntersectActionOptions,
 ): Attachment<HTMLElement>;
+
+// `Action`'s attribute generic only teaches svelte2tsx about `onobserve`/`onintersect`
+// for `use:intersect`; attachments have no equivalent mechanism, so `onobserve`/
+// `onintersect` must be declared as HTML attributes here for `{@attach intersectAttachment(...)}`
+// to type-check.
+declare module "svelte/elements" {
+  export interface HTMLAttributes<T> {
+    onobserve?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+    onintersect?: (
+      event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>,
+    ) => void;
+  }
+}

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -61,10 +61,6 @@ export function intersectAttachment(
   getOptions?: () => IntersectActionOptions,
 ): Attachment<HTMLElement>;
 
-// `Action`'s attribute generic only teaches svelte2tsx about `onobserve`/`onintersect`
-// for `use:intersect`; attachments have no equivalent mechanism, so `onobserve`/
-// `onintersect` must be declared as HTML attributes here for `{@attach intersectAttachment(...)}`
-// to type-check.
 declare module "svelte/elements" {
   export interface HTMLAttributes<T> {
     onobserve?: (event: CustomEvent<IntersectionObserverEntry>) => void;

--- a/tests/IntersectionObserver.test.svelte
+++ b/tests/IntersectionObserver.test.svelte
@@ -13,15 +13,24 @@
   let element: Props["element"];
   let observer: Props["observer"];
   let skip: Props["skip"] = false;
+  let once: Props["once"] = false;
+  let root: Props["root"] = null;
+  let rootMargin: Props["rootMargin"] = "0px";
+  let threshold: Props["threshold"] = 0;
 
   $: entry?.isIntersecting;
 </script>
 
 <SvelteIntersectionObserver
   {element}
+  {once}
+  {root}
+  {rootMargin}
+  {threshold}
   {skip}
   bind:observer
   bind:intersecting
+  bind:entry
   onobserve={(entry) => {
     entry.intersectionRect; // DOMRectReadOnly
     entry.isIntersecting; // boolean

--- a/tests/MultipleIntersectionObserver.test.svelte
+++ b/tests/MultipleIntersectionObserver.test.svelte
@@ -13,6 +13,10 @@
   let elementEntries: Props["elementEntries"] = new Map();
   let observer: Props["observer"];
   let skip: Props["skip"] = false;
+  let once: Props["once"] = false;
+  let root: Props["root"] = null;
+  let rootMargin: Props["rootMargin"] = "0px";
+  let threshold: Props["threshold"] = 0;
 
   let ref1: null | HTMLDivElement = null;
   let ref2: null | HTMLDivElement = null;
@@ -22,6 +26,10 @@
 
 <MultipleIntersectionObserver
   {elements}
+  {once}
+  {root}
+  {rootMargin}
+  {threshold}
   {skip}
   bind:observer
   bind:elementIntersections

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -12,6 +12,7 @@
 
   let options: IntersectActionOptions = {
     once: true,
+    root: null,
     rootMargin: "0px",
     threshold: 0,
     skip: false,


### PR DESCRIPTION
## Summary
- `{@attach intersectAttachment(...)}` failed `svelte-check` with `Object literal may only specify known properties, and '"onobserve"' does not exist in type 'HTMLProps<"div", HTMLAttributes<any>>'` — `Action`'s attribute generic only teaches `svelte2tsx` about `onobserve`/`onintersect` for `use:intersect`; attachments have no equivalent mechanism.
- Fixes it by augmenting `svelte/elements`'s `HTMLAttributes` to declare `onobserve`/`onintersect`, which also type-checks the `{@attach}` usage documented in the README.

