### PR TITLE
fix: guard against missing IntersectionObserver support

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,7 +1,3 @@
-<script module>
-  let warned = false;
-</script>
-
 <script>
   import { untrack } from "svelte";
 
@@ -44,13 +40,6 @@
 
   const initialize = () => {
     if (typeof IntersectionObserver === "undefined") {
-      if (!warned) {
-        warned = true;
-        console.warn(
-          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
-        );
-      }
-
       observer = null;
       return;
     }

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -1,3 +1,7 @@
+<script module>
+  let warned = false;
+</script>
+
 <script>
   import { untrack } from "svelte";
 
@@ -39,6 +43,18 @@
   let prevSkip = untrack(() => skip);
 
   const initialize = () => {
+    if (typeof IntersectionObserver === "undefined") {
+      if (!warned) {
+        warned = true;
+        console.warn(
+          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
+        );
+      }
+
+      observer = null;
+      return;
+    }
+
     observer = new IntersectionObserver(
       (entries) => {
         for (const _entry of entries) {

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -1,7 +1,3 @@
-<script module>
-  let warned = false;
-</script>
-
 <script>
   import { untrack } from "svelte";
 
@@ -44,13 +40,6 @@
 
   const initialize = () => {
     if (typeof IntersectionObserver === "undefined") {
-      if (!warned) {
-        warned = true;
-        console.warn(
-          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
-        );
-      }
-
       observer = null;
       return;
     }

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -1,3 +1,7 @@
+<script module>
+  let warned = false;
+</script>
+
 <script>
   import { untrack } from "svelte";
 
@@ -39,6 +43,18 @@
   let prevSkip = untrack(() => skip);
 
   const initialize = () => {
+    if (typeof IntersectionObserver === "undefined") {
+      if (!warned) {
+        warned = true;
+        console.warn(
+          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
+        );
+      }
+
+      observer = null;
+      return;
+    }
+
     observer = new IntersectionObserver(
       (entries) => {
         for (const _entry of entries) {

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -1,7 +1,5 @@
 import { fromAction } from "svelte/attachments";
 
-let warned = false;
-
 /**
  * Svelte action that observes `node` with the Intersection Observer API.
  * Dispatches `observe` (on every change) and `intersect` (on entering the
@@ -22,16 +20,7 @@ export function intersect(node, options = {}) {
   let observer;
 
   const createObserver = () => {
-    if (typeof IntersectionObserver === "undefined") {
-      if (!warned) {
-        warned = true;
-        console.warn(
-          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
-        );
-      }
-
-      return null;
-    }
+    if (typeof IntersectionObserver === "undefined") return null;
 
     return new IntersectionObserver(
       (entries) => {

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -1,5 +1,7 @@
 import { fromAction } from "svelte/attachments";
 
+let warned = false;
+
 /**
  * Svelte action that observes `node` with the Intersection Observer API.
  * Dispatches `observe` (on every change) and `intersect` (on entering the
@@ -16,26 +18,38 @@ export function intersect(node, options = {}) {
     skip = false,
   } = options;
 
-  /** @type {IntersectionObserver} */
+  /** @type {null | IntersectionObserver} */
   let observer;
 
-  const createObserver = () =>
-    new IntersectionObserver(
+  const createObserver = () => {
+    if (typeof IntersectionObserver === "undefined") {
+      if (!warned) {
+        warned = true;
+        console.warn(
+          "svelte-intersection-observer: `IntersectionObserver` is not available in this environment. No observation will occur; consider using a polyfill if you need to support it.",
+        );
+      }
+
+      return null;
+    }
+
+    return new IntersectionObserver(
       (entries) => {
         for (const entry of entries) {
           node.dispatchEvent(new CustomEvent("observe", { detail: entry }));
 
           if (entry.isIntersecting) {
             node.dispatchEvent(new CustomEvent("intersect", { detail: entry }));
-            if (once) observer.unobserve(node);
+            if (once) observer?.unobserve(node);
           }
         }
       },
       { root, rootMargin, threshold },
     );
+  };
 
   observer = createObserver();
-  if (!skip) observer.observe(node);
+  if (!skip) observer?.observe(node);
 
   return {
     /** @param {import("./intersect.svelte.d.ts").IntersectActionOptions} [newOptions] */
@@ -54,18 +68,18 @@ export function intersect(node, options = {}) {
         rootMargin = newOptions.rootMargin ?? "0px";
         threshold = newOptions.threshold ?? 0;
 
-        observer.disconnect();
+        observer?.disconnect();
         observer = createObserver();
-        if (!newSkip) observer.observe(node);
+        if (!newSkip) observer?.observe(node);
       } else if (newSkip !== skip) {
-        if (newSkip) observer.unobserve(node);
-        else observer.observe(node);
+        if (newSkip) observer?.unobserve(node);
+        else observer?.observe(node);
       }
 
       skip = newSkip;
     },
     destroy() {
-      observer.disconnect();
+      observer?.disconnect();
     },
   };
 }

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -611,14 +611,10 @@ test.describe("Missing IntersectionObserver support", () => {
     });
   });
 
-  test("IntersectionObserver component - degrades gracefully with a single warning", async ({
+  test("IntersectionObserver component - degrades gracefully without throwing", async ({
     page,
   }) => {
-    const warnings: string[] = [];
     const pageErrors: Error[] = [];
-    page.on("console", (msg) => {
-      if (msg.type() === "warning") warnings.push(msg.text());
-    });
     page.on("pageerror", (err) => pageErrors.push(err));
 
     await page.goto("/basic.html");
@@ -629,9 +625,6 @@ test.describe("Missing IntersectionObserver support", () => {
     await expect(page.locator("header")).toHaveText(/Element is not in view/);
 
     expect(pageErrors).toEqual([]);
-    expect(
-      warnings.filter((w) => w.includes("IntersectionObserver")),
-    ).toHaveLength(1);
   });
 
   test("MultipleIntersectionObserver component - degrades gracefully without throwing", async ({

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -600,3 +600,69 @@ test("Multiple elements - binding pattern", async ({ page }) => {
     "false",
   );
 });
+
+test.describe("Missing IntersectionObserver support", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "IntersectionObserver", {
+        value: undefined,
+        configurable: true,
+      });
+    });
+  });
+
+  test("IntersectionObserver component - degrades gracefully with a single warning", async ({
+    page,
+  }) => {
+    const warnings: string[] = [];
+    const pageErrors: Error[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "warning") warnings.push(msg.text());
+    });
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.goto("/basic.html");
+    await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(200);
+    await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+    expect(pageErrors).toEqual([]);
+    expect(
+      warnings.filter((w) => w.includes("IntersectionObserver")),
+    ).toHaveLength(1);
+  });
+
+  test("MultipleIntersectionObserver component - degrades gracefully without throwing", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.goto("/multiple-basic.html");
+    await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
+
+    await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
+    await page.waitForTimeout(200);
+    await expect(page.getByTestId("item-1-indicator")).toHaveText(/Item 1: ✗/);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test("intersect action - degrades gracefully without throwing", async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err));
+
+    await page.goto("/action.html");
+    await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(200);
+    await expect(page.locator("header")).toHaveText(/Element is not in view/);
+
+    expect(pageErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- All three surfaces (`IntersectionObserver.svelte`, `MultipleIntersectionObserver.svelte`, and `intersect.svelte.js`'s `createObserver()`) unconditionally called `new IntersectionObserver(...)`, throwing `ReferenceError` and taking down the whole component tree in environments where it's unavailable (SSR/non-browser environments, older browsers without a polyfill, some headless test setups).
- Each surface now checks `typeof IntersectionObserver === "undefined"` before constructing and silently no-ops: `observer` stays `null`, `intersecting`/`elementIntersections` stay at their default falsy values, no exception is thrown.

## Test plan
- [x] Added 3 Playwright tests under a new "Missing IntersectionObserver support" describe block that stub `window.IntersectionObserver = undefined` via `page.addInitScript` and assert no page errors, covering the component, `MultipleIntersectionObserver`, and the `intersect` action.
- [x] `bun test:types` — 0 errors
- [x] `bun test:e2e` — 29/29 passed