### PR TITLE
feat: add createIntersectionGroup for shared-observer list usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,9 @@ A bare `intersect`/`intersectAttachment` inside an `#each` block creates one nat
 <script>
   import { createIntersectionGroup } from "svelte-intersection-observer";
 
-  let groupItems = Array.from({ length: 100 }, (_, i) => ({ id: i, intersecting: false }));
+  let groupItems = $state(
+    Array.from({ length: 100 }, (_, i) => ({ id: i, intersecting: false })),
+  );
 
   const group = createIntersectionGroup(); // one observer, however many items
 </script>

--- a/README.md
+++ b/README.md
@@ -302,46 +302,6 @@ Attachments have a few architectural advantages over actions:
 
 **Note**: unlike `use:intersect`, which takes the options object directly, `intersectAttachment` takes a function that _returns_ the options object (this is how `fromAction` tracks reactive dependencies). `intersect` remains fully supported; use whichever fits your codebase.
 
-### `createIntersectionGroup` factory
-
-A bare `intersect`/`intersectAttachment` inside an `#each` block creates one native `IntersectionObserver` per iteration — for a long list, that's N observers instead of 1. `createIntersectionGroup` fixes this for the action/attachment API: call it once to create a group, then call `group.attach(...)` once per element to get an attachment that shares a single underlying observer across the whole group.
-
-```svelte
-<script>
-  import { createIntersectionGroup } from "svelte-intersection-observer";
-
-  let items = Array.from({ length: 100 }, (_, i) => ({
-    id: i + 1,
-    text: `Item ${i + 1}`,
-    intersecting: false,
-  }));
-
-  const group = createIntersectionGroup(); // one observer, however many items
-</script>
-
-{#each items as item (item.id)}
-  <div
-    {@attach group.attach({
-      onobserve: (entry) => (item.intersecting = entry.isIntersecting),
-    })}
-  >
-    {item.text}: {item.intersecting ? "✓" : "✗"}
-  </div>
-{/each}
-```
-
-`root`/`rootMargin`/`threshold` configure the one shared observer, so they're passed once to `createIntersectionGroup` itself (as a function, for the same reactive-dependency-tracking reason `intersectAttachment` takes one) rather than per element:
-
-```svelte no-eval
-const group = createIntersectionGroup(() => ({
-  root: container,
-  rootMargin: "0px",
-  threshold: 0.5,
-}));
-```
-
-`once`, `skip`, `onobserve`, and `onintersect` are the only options that make sense per element, so those are what `group.attach(...)` accepts.
-
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements with a single shared observer instead of instantiating a new one for every element.
@@ -422,6 +382,42 @@ For performance, use `MultipleIntersectionObserver` to observe multiple elements
 As with the scroll-to-end example, `root` must be an element that scrolls on its own; here, `itemsContainer` has an explicit `height` and `overflow-y: auto`.
 
 **Avoid** using the single-element `IntersectionObserver` component inside an `#each` block with one variable shared across iterations (e.g. `let node;` declared outside the loop and bound via `bind:this={node}` inside it). Every iteration overwrites the same `node`, so each observer instance keeps re-observing a moving target, which can produce an infinite update loop. Use `MultipleIntersectionObserver` with a per-item ref, as shown above, instead.
+
+### `createIntersectionGroup` factory
+
+A bare `intersect`/`intersectAttachment` inside an `#each` block creates one native `IntersectionObserver` per iteration — for a long list, that's N observers instead of 1. `createIntersectionGroup` fixes this for the action/attachment API: call it once to create a group, then call `group.attach(...)` once per element to get an attachment that shares a single underlying observer across the whole group.
+
+```svelte
+<script>
+  import { createIntersectionGroup } from "svelte-intersection-observer";
+
+  let groupItems = Array.from({ length: 100 }, (_, i) => ({ id: i, intersecting: false }));
+
+  const group = createIntersectionGroup(); // one observer, however many items
+</script>
+
+{#each groupItems as item (item.id)}
+  <div
+    {@attach group.attach({
+      onobserve: (entry) => (item.intersecting = entry.isIntersecting),
+    })}
+  >
+    Item {item.id}: {item.intersecting ? "✓" : "✗"}
+  </div>
+{/each}
+```
+
+`root`/`rootMargin`/`threshold` configure the one shared observer, so they're passed once to `createIntersectionGroup` itself (as a function, for the same reactive-dependency-tracking reason `intersectAttachment` takes one) rather than per element:
+
+```js
+const group = createIntersectionGroup(() => ({
+  root: container,
+  rootMargin: "0px",
+  threshold: 0.5,
+}));
+```
+
+`once`, `skip`, `onobserve`, and `onintersect` are the only options that make sense per element, so those are what `group.attach(...)` accepts.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -392,19 +392,28 @@ A bare `intersect`/`intersectAttachment` inside an `#each` block creates one nat
   import { createIntersectionGroup } from "svelte-intersection-observer";
 
   let groupItems = $state(
-    Array.from({ length: 100 }, (_, i) => ({ id: i, intersecting: false })),
+    Array.from({ length: 5 }, (_, i) => ({ id: i, intersecting: false })),
   );
 
   const group = createIntersectionGroup(); // one observer, however many items
 </script>
 
+<header>
+  {#each groupItems as item (item.id)}
+    <div class:intersecting={item.intersecting}>
+      Item {item.id}: {item.intersecting ? "✓" : "✗"}
+    </div>
+  {/each}
+</header>
+
 {#each groupItems as item (item.id)}
   <div
+    class:intersecting={item.intersecting}
     {@attach group.attach({
       onobserve: (entry) => (item.intersecting = entry.isIntersecting),
     })}
   >
-    Item {item.id}: {item.intersecting ? "✓" : "✗"}
+    Item {item.id}
   </div>
 {/each}
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This zero-dependency library offers several ways to observe elements:
 - `MultipleIntersectionObserver`: component for observing multiple elements (shared observer for better performance)
 - `intersect`: action for observing an element directly with `use:`
 - `intersectAttachment`: attachment for observing an element directly with `{@attach}` (Svelte 5.29+)
+- `createIntersectionGroup`: factory for observing a list of elements with `{@attach}`, backed by a single shared observer (Svelte 5.29+)
 
 Try it in the [Svelte REPL](https://svelte.dev/repl/8cd2327a580c4f429c71f7df999bd51d).
 
@@ -301,6 +302,46 @@ Attachments have a few architectural advantages over actions:
 
 **Note**: unlike `use:intersect`, which takes the options object directly, `intersectAttachment` takes a function that _returns_ the options object (this is how `fromAction` tracks reactive dependencies). `intersect` remains fully supported; use whichever fits your codebase.
 
+### `createIntersectionGroup` factory
+
+A bare `intersect`/`intersectAttachment` inside an `#each` block creates one native `IntersectionObserver` per iteration — for a long list, that's N observers instead of 1. `createIntersectionGroup` fixes this for the action/attachment API: call it once to create a group, then call `group.attach(...)` once per element to get an attachment that shares a single underlying observer across the whole group.
+
+```svelte
+<script>
+  import { createIntersectionGroup } from "svelte-intersection-observer";
+
+  let items = Array.from({ length: 100 }, (_, i) => ({
+    id: i + 1,
+    text: `Item ${i + 1}`,
+    intersecting: false,
+  }));
+
+  const group = createIntersectionGroup(); // one observer, however many items
+</script>
+
+{#each items as item (item.id)}
+  <div
+    {@attach group.attach({
+      onobserve: (entry) => (item.intersecting = entry.isIntersecting),
+    })}
+  >
+    {item.text}: {item.intersecting ? "✓" : "✗"}
+  </div>
+{/each}
+```
+
+`root`/`rootMargin`/`threshold` configure the one shared observer, so they're passed once to `createIntersectionGroup` itself (as a function, for the same reactive-dependency-tracking reason `intersectAttachment` takes one) rather than per element:
+
+```svelte no-eval
+const group = createIntersectionGroup(() => ({
+  root: container,
+  rootMargin: "0px",
+  threshold: 0.5,
+}));
+```
+
+`once`, `skip`, `onobserve`, and `onintersect` are the only options that make sense per element, so those are what `group.attach(...)` accepts.
+
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements with a single shared observer instead of instantiating a new one for every element.
@@ -475,6 +516,35 @@ Both callbacks are called with:
 - **onintersect**: fired on the element when it is intersecting the viewport
 
 The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
+
+### `createIntersectionGroup`
+
+```ts
+function createIntersectionGroup(
+  getSharedOptions?: () => IntersectGroupSharedOptions,
+): IntersectionGroup;
+```
+
+#### Shared options
+
+Passed once to `createIntersectionGroup`; apply to every element in the group.
+
+| Name       | Description                                           | Type                                                               | Default value |
+| :--------- | :----------------------------------------------------- | :----------------------------------------------------------------- | :------------ |
+| root       | Containing element                                    | `null` or `HTMLElement`                                            | `null`        |
+| rootMargin | Margin offset of the containing element               | `string`                                                           | `"0px"`       |
+| threshold  | Percentage of element visibility to trigger an event  | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`           |
+
+#### `group.attach(options)` per-node options
+
+Passed once per element, to `group.attach(...)`.
+
+| Name       | Description                                               | Type                                                    | Default value |
+| :--------- | :---------------------------------------------------------- | :------------------------------------------------------- | :------------ |
+| once       | Unobserve the element after the first intersection event  | `boolean`                                               | `false`       |
+| skip       | Skip observing this element without affecting the group   | `boolean`                                               | `false`       |
+| onobserve  | Called when the element is first observed or when an intersection change occurs | `(entry: IntersectionObserverEntry) => void` | `undefined` |
+| onintersect | Called when the element is intersecting the viewport      | `(entry: IntersectionObserverEntry) => void`            | `undefined`   |
 
 ### `IntersectionObserverEntry` interface
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,13 @@
 export { default } from "./IntersectionObserver.svelte";
-export type { IntersectActionOptions } from "./intersect.svelte.js";
-export { intersect, intersectAttachment } from "./intersect.svelte.js";
+export type {
+  IntersectActionOptions,
+  IntersectGroupNodeOptions,
+  IntersectGroupSharedOptions,
+  IntersectionGroup,
+} from "./intersect.svelte.js";
+export {
+  createIntersectionGroup,
+  intersect,
+  intersectAttachment,
+} from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,7 @@
 export { default } from "./IntersectionObserver.svelte";
-export { intersect, intersectAttachment } from "./intersect.svelte.js";
+export {
+  createIntersectionGroup,
+  intersect,
+  intersectAttachment,
+} from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -69,3 +69,75 @@ declare module "svelte/elements" {
     ) => void;
   }
 }
+
+/**
+ * Options shared by every node in an `createIntersectionGroup` group. These
+ * configure the one underlying `IntersectionObserver` instance, so they
+ * can't vary per node.
+ */
+export interface IntersectGroupSharedOptions {
+  /**
+   * Specify the containing element.
+   * Defaults to the browser viewport.
+   * @default null
+   */
+  root?: null | HTMLElement;
+
+  /**
+   * Margin offset of the containing element.
+   * @default "0px"
+   */
+  rootMargin?: string;
+
+  /**
+   * Percentage of element visibility to trigger an event.
+   * Value must be a number between 0 and 1, or an array of numbers between 0 and 1.
+   * @default 0
+   */
+  threshold?: number | number[];
+}
+
+/**
+ * Per-node options for a single element within an `createIntersectionGroup` group.
+ */
+export interface IntersectGroupNodeOptions {
+  /**
+   * Set to `true` to unobserve the element
+   * after it intersects the viewport.
+   * @default false
+   */
+  once?: boolean;
+
+  /**
+   * Set to `true` to skip observing this element without
+   * affecting the rest of the group.
+   * @default false
+   */
+  skip?: boolean;
+
+  /** Called when the element is first observed and also whenever an intersection change occurs. */
+  onobserve?: (entry: IntersectionObserverEntry) => void;
+
+  /** Called only when the element is intersecting the viewport. */
+  onintersect?: (
+    entry: IntersectionObserverEntry & { isIntersecting: true },
+  ) => void;
+}
+
+export interface IntersectionGroup {
+  /**
+   * Returns an attachment for a single node in the group. Call once per
+   * element in a loop, e.g. `{@attach group.attach({ onobserve })}`.
+   */
+  attach(options?: IntersectGroupNodeOptions): Attachment<HTMLElement>;
+}
+
+/**
+ * Creates a group of elements backed by a single shared `IntersectionObserver`
+ * instance, for use with `{@attach}` inside an `#each` block. Brings
+ * `MultipleIntersectionObserver`'s single-observer performance benefit to the
+ * action/attachment API.
+ */
+export function createIntersectionGroup(
+  getSharedOptions?: () => IntersectGroupSharedOptions,
+): IntersectionGroup;

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -79,3 +79,79 @@ export function intersect(node, options = {}) {
 export function intersectAttachment(getOptions = () => ({})) {
   return fromAction(intersect, getOptions);
 }
+
+/**
+ * Creates a group of elements backed by a single shared `IntersectionObserver`
+ * instance, for use with `{@attach}` inside an `#each` block. This brings
+ * `MultipleIntersectionObserver`'s single-observer performance benefit to the
+ * action/attachment API, where a bare `intersect`/`intersectAttachment` inside
+ * a loop would otherwise create one `IntersectionObserver` per element.
+ *
+ * `root`/`rootMargin`/`threshold` are shared across every node in the group
+ * (they configure the one underlying observer); only `once`/`skip` and the
+ * `onobserve`/`onintersect` callbacks are meaningful per node.
+ * @param {() => import("./intersect.svelte.d.ts").IntersectGroupSharedOptions} [getSharedOptions]
+ * @returns {import("./intersect.svelte.d.ts").IntersectionGroup}
+ */
+export function createIntersectionGroup(getSharedOptions = () => ({})) {
+  /** @type {IntersectionObserver | undefined} */
+  let observer;
+
+  /** @type {Map<Element, import("./intersect.svelte.d.ts").IntersectGroupNodeOptions>} */
+  const callbacks = new Map();
+
+  const handleEntries = (
+    /** @type {IntersectionObserverEntry[]} */ entries,
+  ) => {
+    for (const entry of entries) {
+      const target = entry.target;
+      const nodeOptions = callbacks.get(target);
+
+      nodeOptions?.onobserve?.(entry);
+
+      if (entry.isIntersecting) {
+        nodeOptions?.onintersect?.(
+          /** @type {IntersectionObserverEntry & { isIntersecting: true }} */ (
+            entry
+          ),
+        );
+        if (nodeOptions?.once) observer?.unobserve(target);
+      }
+    }
+  };
+
+  /**
+   * @param {import("./intersect.svelte.d.ts").IntersectGroupNodeOptions} [nodeOptions]
+   */
+  function attach(nodeOptions = {}) {
+    return (/** @type {Element} */ node) => {
+      if (!observer) {
+        const {
+          root = null,
+          rootMargin = "0px",
+          threshold = 0,
+        } = getSharedOptions();
+        observer = new IntersectionObserver(handleEntries, {
+          root,
+          rootMargin,
+          threshold,
+        });
+      }
+
+      callbacks.set(node, nodeOptions);
+      if (!nodeOptions.skip) observer.observe(node);
+
+      return () => {
+        observer?.unobserve(node);
+        callbacks.delete(node);
+
+        if (callbacks.size === 0) {
+          observer?.disconnect();
+          observer = undefined;
+        }
+      };
+    };
+  }
+
+  return { attach };
+}

--- a/tests/e2e/fixtures/IntersectionGroupFixture.svelte
+++ b/tests/e2e/fixtures/IntersectionGroupFixture.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { createIntersectionGroup } from "svelte-intersection-observer";
+
+  // Spy on the global constructor to verify the group shares a single
+  // underlying `IntersectionObserver` instead of one per element.
+  let observerCount = 0;
+  const NativeIntersectionObserver = window.IntersectionObserver;
+
+  window.IntersectionObserver = class extends NativeIntersectionObserver {
+    constructor(
+      ...args: ConstructorParameters<typeof NativeIntersectionObserver>
+    ) {
+      super(...args);
+      observerCount += 1;
+    }
+  };
+
+  const group = createIntersectionGroup();
+
+  const ids = [1, 2, 3];
+  let visible: Record<number, boolean> = {};
+</script>
+
+<header>
+  <p data-testid="observer-count">Observer count: {observerCount}</p>
+  {#each ids as id}
+    <p data-testid="item-{id}-status">
+      Item {id} is {visible[id] ? "visible" : "not visible"}
+    </p>
+  {/each}
+</header>
+
+{#each ids as id (id)}
+  <div
+    data-testid="item-{id}"
+    {@attach group.attach({
+      onobserve: (entry) => {
+        visible = { ...visible, [id]: entry.isIntersecting };
+      },
+    })}
+  >
+    Item {id}
+  </div>
+{/each}
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    height: 50vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+    margin-bottom: 100vh;
+  }
+
+  div:first-of-type {
+    margin-top: calc(100vh + 1px);
+  }
+</style>

--- a/tests/e2e/fixtures/intersection-group.html
+++ b/tests/e2e/fixtures/intersection-group.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Intersection Group Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./intersection-group.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/intersection-group.ts
+++ b/tests/e2e/fixtures/intersection-group.ts
@@ -1,0 +1,4 @@
+import IntersectionGroupFixture from "./IntersectionGroupFixture.svelte";
+import { mount } from "./mount";
+
+mount(IntersectionGroupFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -487,6 +487,65 @@ test("Multiple elements - basic pattern", async ({ page }) => {
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✗/);
 });
 
+test("Intersection group - shares a single observer and dispatches per-node callbacks", async ({
+  page,
+}) => {
+  await page.goto("/intersection-group.html");
+
+  await expect(page.getByTestId("observer-count")).toHaveText(
+    /Observer count: 1/,
+  );
+
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight + 50));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, window.innerHeight * 2 + 50));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+  await expect(page.getByTestId("item-2-status")).toHaveText(
+    /Item 2 is not visible/,
+  );
+  await expect(page.getByTestId("item-3-status")).toHaveText(
+    /Item 3 is visible/,
+  );
+
+  // Constructing the group and observing three elements should not have
+  // created any additional native `IntersectionObserver` instances.
+  await expect(page.getByTestId("observer-count")).toHaveText(
+    /Observer count: 1/,
+  );
+});
+
 test("Each block - bind:this + bind:intersecting per item does not deadlock and tracks independently", async ({
   page,
 }) => {

--- a/tests/intersect.test.svelte
+++ b/tests/intersect.test.svelte
@@ -4,6 +4,7 @@
    */
 
   import {
+    createIntersectionGroup,
     type IntersectActionOptions,
     intersect,
     // biome-ignore lint/correctness/noUnusedImports: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
@@ -17,6 +18,15 @@
     threshold: 0,
     skip: false,
   };
+
+  // biome-ignore lint/correctness/noUnusedVariables: used in {@attach}, which Biome's Svelte parser doesn't yet analyze for usages
+  const group = createIntersectionGroup(() => ({
+    root: null,
+    rootMargin: "0px",
+    threshold: 0,
+  }));
+
+  const ids = [1, 2, 3];
 </script>
 
 <div
@@ -44,3 +54,21 @@
 >
   Hello world
 </div>
+
+{#each ids as id (id)}
+  <div
+    {@attach group.attach({
+      once: true,
+      skip: false,
+      onobserve: (entry) => {
+        entry.intersectionRect; // DOMRectReadOnly
+        entry.isIntersecting; // boolean
+      },
+      onintersect: (entry) => {
+        entry.isIntersecting; // true
+      },
+    })}
+  >
+    Item {id}
+  </div>
+{/each}


### PR DESCRIPTION
## Summary

- Adds `createIntersectionGroup(getSharedOptions)` to `src/intersect.svelte.js`: a factory that backs a list of elements with a single shared `IntersectionObserver`, for use with `{@attach}` inside an `#each` block.
- Brings `MultipleIntersectionObserver`'s single-shared-observer performance benefit to the action/attachment API. Previously, a bare `intersect`/`intersectAttachment` inside a loop created one native observer per element — for a long list, N observers instead of 1, with no lighter-weight way to opt into the shared-observer behavior without switching to the component API's `elements`/`bind:this` wiring.
- `root`/`rootMargin`/`threshold` are shared across the group (passed once to `createIntersectionGroup`); `once`/`skip`/`onobserve`/`onintersect` are per-node (passed to `group.attach(...)`).
- Exports `createIntersectionGroup` and its types (`IntersectGroupSharedOptions`, `IntersectGroupNodeOptions`, `IntersectionGroup`) from `src/index.js`/`src/index.d.ts`.
- Documents the new API in `README.md` with an `#each` example and API reference tables.

## Test plan

- [x] `bun test:types` — 0 errors (extended `tests/intersect.test.svelte` with `createIntersectionGroup` usage)
- [x] `bun test:e2e` — added `IntersectionGroupFixture.svelte` fixture that monkey-patches the global `IntersectionObserver` constructor to assert only one instance is created across 3 grouped elements, plus a new Playwright test asserting per-node `onobserve` dispatch and the single-observer count. All 27 e2e tests pass.