### PR TITLE
feat: add `createIntersectionObserver` rune-based composable

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Attachments have a few architectural advantages over actions:
 
 For consumers who want Intersection Observer state without wrapping markup in a component, `createIntersectionObserver` is a script-only rune-based composable: call it in `<script>` to get reactive `intersecting`/`entry` getters, then apply `attach` to the node with `{@attach}`.
 
-```svelte
+```svelte no-eval
 <script>
   import { createIntersectionObserver } from "svelte-intersection-observer";
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,24 @@ Attachments have a few architectural advantages over actions:
 
 **Note**: unlike `use:intersect`, which takes the options object directly, `intersectAttachment` takes a function that _returns_ the options object (this is how `fromAction` tracks reactive dependencies). `intersect` remains fully supported; use whichever fits your codebase.
 
+### `createIntersectionObserver` composable
+
+For consumers who want Intersection Observer state without wrapping markup in a component, `createIntersectionObserver` is a script-only rune-based composable: call it in `<script>` to get reactive `intersecting`/`entry` getters, then apply `attach` to the node with `{@attach}`.
+
+```svelte
+<script>
+  import { createIntersectionObserver } from "svelte-intersection-observer";
+
+  const observer = createIntersectionObserver(() => ({ threshold: 0.5 }));
+</script>
+
+<div {@attach observer.attach}>
+  {observer.intersecting ? "In view" : "Not in view"}
+</div>
+```
+
+`createIntersectionObserver` takes the same options as `intersectAttachment` (as a function returning the options object) and reuses its underlying observer logic.
+
 ### Multiple elements
 
 For performance, use `MultipleIntersectionObserver` to observe multiple elements with a single shared observer instead of instantiating a new one for every element.
@@ -475,6 +493,18 @@ Both callbacks are called with:
 - **onintersect**: fired on the element when it is intersecting the viewport
 
 The `e.detail` dispatched by the `observe` and `intersect` events is an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) interface.
+
+### `createIntersectionObserver` composable
+
+Takes the same options as [`intersectAttachment`](#options) (see above).
+
+#### Return value
+
+| Name         | Description                                             | Type                                                                                                                 |
+| :----------- | :------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| intersecting | `true` if the observed element is intersecting the viewport | `boolean`                                                                                                          |
+| entry        | Observed element metadata                                | `null` or [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) |
+| attach       | Attachment to apply to the observed element via `{@attach}` | [`Attachment<HTMLElement>`](https://svelte.dev/docs/svelte/svelte-attachments)                                    |
 
 ### `IntersectionObserverEntry` interface
 

--- a/src/create-intersection-observer.svelte.d.ts
+++ b/src/create-intersection-observer.svelte.d.ts
@@ -1,0 +1,22 @@
+import type { Attachment } from "svelte/attachments";
+import type { IntersectActionOptions } from "./intersect.svelte.js";
+
+export interface IntersectionObserverState {
+  /** `true` if the observed element is intersecting the viewport. */
+  readonly intersecting: boolean;
+
+  /** Observed element metadata. */
+  readonly entry: null | IntersectionObserverEntry;
+
+  /** Attachment to apply to the observed element via `{@attach}`. */
+  attach: Attachment<HTMLElement>;
+}
+
+/**
+ * Rune-based composable that observes the attached element with the
+ * Intersection Observer API, without a wrapper component or `use:`/`{@attach}`
+ * directive of your own.
+ */
+export function createIntersectionObserver(
+  getOptions?: () => IntersectActionOptions,
+): IntersectionObserverState;

--- a/src/create-intersection-observer.svelte.js
+++ b/src/create-intersection-observer.svelte.js
@@ -1,0 +1,46 @@
+import { intersectAttachment } from "./intersect.svelte.js";
+
+/**
+ * Rune-based composable that observes the attached element with the
+ * Intersection Observer API, exposing `intersecting`/`entry` as reactive
+ * getters. Wraps `intersectAttachment`, reusing its observe/unobserve/cleanup
+ * logic, and listens for the `observe` `CustomEvent` it dispatches on the
+ * node to keep state in sync.
+ * @param {() => import("./intersect.svelte.d.ts").IntersectActionOptions} [getOptions]
+ */
+export function createIntersectionObserver(getOptions = () => ({})) {
+  let intersecting = $state(false);
+  let entry = $state(/** @type {null | IntersectionObserverEntry} */ (null));
+
+  const attachment = intersectAttachment(getOptions);
+
+  /** @param {HTMLElement} node */
+  function attach(node) {
+    /** @param {Event} event */
+    const onObserve = (event) => {
+      const detail = /** @type {CustomEvent<IntersectionObserverEntry>} */ (
+        event
+      ).detail;
+      entry = detail;
+      intersecting = detail.isIntersecting;
+    };
+
+    node.addEventListener("observe", onObserve);
+    const cleanup = attachment(node);
+
+    return () => {
+      node.removeEventListener("observe", onObserve);
+      if (typeof cleanup === "function") cleanup();
+    };
+  }
+
+  return {
+    get intersecting() {
+      return intersecting;
+    },
+    get entry() {
+      return entry;
+    },
+    attach,
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+export type { IntersectionObserverState } from "./create-intersection-observer.svelte.js";
+export { createIntersectionObserver } from "./create-intersection-observer.svelte.js";
 export { default } from "./IntersectionObserver.svelte";
 export type { IntersectActionOptions } from "./intersect.svelte.js";
 export { intersect, intersectAttachment } from "./intersect.svelte.js";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { createIntersectionObserver } from "./create-intersection-observer.svelte.js";
 export { default } from "./IntersectionObserver.svelte";
 export { intersect, intersectAttachment } from "./intersect.svelte.js";
 export { default as MultipleIntersectionObserver } from "./MultipleIntersectionObserver.svelte";

--- a/tests/create-intersection-observer.test.svelte
+++ b/tests/create-intersection-observer.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  /**
+   * Run `bun test:types` to test the type definitions of the composable using `svelte-check`.
+   */
+
+  import { createIntersectionObserver } from "svelte-intersection-observer";
+
+  const observer = createIntersectionObserver(() => ({
+    once: true,
+    root: null,
+    rootMargin: "0px",
+    threshold: 0,
+    skip: false,
+  }));
+
+  observer.intersecting; // boolean
+  observer.entry; // null | IntersectionObserverEntry
+</script>
+
+<div {@attach observer.attach}>
+  {observer.intersecting ? "In view" : "Not in view"}
+</div>

--- a/tests/e2e/fixtures/CreateIntersectionObserverFixture.svelte
+++ b/tests/e2e/fixtures/CreateIntersectionObserverFixture.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { createIntersectionObserver } from "svelte-intersection-observer";
+
+  const observer = createIntersectionObserver(() => ({ once: true }));
+  let intersectCount = $derived(observer.intersecting ? 1 : 0);
+</script>
+
+<header class:intersecting={observer.intersecting}>
+  {observer.intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="intersect-count">Intersect count: {intersectCount}</p>
+</header>
+
+<div {@attach observer.attach}>Hello world</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/create-intersection-observer.html
+++ b/tests/e2e/fixtures/create-intersection-observer.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Create Intersection Observer Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./create-intersection-observer.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/create-intersection-observer.ts
+++ b/tests/e2e/fixtures/create-intersection-observer.ts
@@ -1,0 +1,4 @@
+import CreateIntersectionObserverFixture from "./CreateIntersectionObserverFixture.svelte";
+import { mount } from "./mount";
+
+mount(CreateIntersectionObserverFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -246,6 +246,32 @@ test("Attachment - {@attach intersectAttachment} dispatches observe/intersect ev
   );
 });
 
+test("createIntersectionObserver - updates intersecting/entry via {@attach observer.attach} and honors once", async ({
+  page,
+}) => {
+  await page.goto("/create-intersection-observer.html");
+  const app = page.locator("#app");
+
+  await expect(page.locator("header")).toHaveText(/Element is not in view/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 0/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(page.locator("header")).toHaveText(/Element is in view/);
+  await expect(app).toHaveText(/Hello world/);
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("intersect-count")).toHaveText(
+    /Intersect count: 1/,
+  );
+});
+
 test("Attachment - reinitializes the observer when the parameter changes at runtime", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary

- Adds `createIntersectionObserver(getOptions)`, a script-only rune-based composable that returns reactive `intersecting`/`entry` getters plus an `attach` for `{@attach}` — no wrapper component or `use:`/`{@attach}` directive of your own required.
- Composes with the existing `intersectAttachment` (reusing its observe/unobserve/cleanup logic) rather than reimplementing observer management, by listening for the `observe` `CustomEvent` it dispatches on the node.
- Exported from `src/index.js`/`src/index.d.ts`; documented in `README.md`.
- Purely additive — no changes to existing exports' behavior.

## Test plan

- [x] `bun test:types` — 0 errors
- [x] `bun test:e2e` — 27/27 passed (new fixture + Playwright test mirroring the `intersectAttachment` coverage)