### PR TITLE
perf(multiple-intersection-observer): use Set-based diffing for elements array

### DIFF
--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -33,8 +33,8 @@
     children,
   } = $props();
 
-  /** @type {(HTMLElement | null)[]} */
-  let prevElements = [];
+  /** @type {Set<HTMLElement | null>} */
+  let prevElements = new Set();
 
   let prevSkip = untrack(() => skip);
 
@@ -70,7 +70,7 @@
   };
 
   $effect(() => {
-    prevElements = [];
+    prevElements = new Set();
     initialize();
 
     return () => {
@@ -85,8 +85,10 @@
     const activeObserver = observer;
 
     if (currentElements.length > 0) {
+      const currentSet = new Set(currentElements);
+
       const newElements = currentElements.filter(
-        (el) => el && !prevElements.includes(el),
+        (el) => el && !prevElements.has(el),
       );
 
       if (!isSkipped) {
@@ -95,15 +97,15 @@
         }
       }
 
-      const removedElements = prevElements.filter(
-        (el) => el && !currentElements.includes(el),
+      const removedElements = [...prevElements].filter(
+        (el) => el && !currentSet.has(el),
       );
 
       for (const el of removedElements) {
         if (el) activeObserver?.unobserve(el);
       }
 
-      prevElements = [...currentElements];
+      prevElements = currentSet;
     }
 
     if (isSkipped !== prevSkip) {


### PR DESCRIPTION
## Summary
- Replace `Array#includes`-based diffing of the `elements` array in `MultipleIntersectionObserver`'s update effect with `Set`-based diffing, turning an O(n^2) per-update diff into O(n).
- `prevElements` is now stored as a `Set` instead of an array, avoiding a rebuild-from-array on every effect run.
- Pure internal refactor — no change to bindable props, callback timing, or snippet params.

## Test plan
- [x] `bun test:types` — 0 errors, 0 warnings
- [x] `bun test:e2e` — 26/26 passed (existing suite, unmodified)