### PR TITLE
perf: avoid recreating observer for value-equal threshold/root/rootMargin

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -38,6 +38,10 @@
 
   let prevSkip = untrack(() => skip);
 
+  const configKey = $derived(
+    `${root}|${rootMargin}|${JSON.stringify(threshold)}`,
+  );
+
   const initialize = () => {
     observer = new IntersectionObserver(
       (entries) => {
@@ -63,8 +67,12 @@
   };
 
   $effect(() => {
-    prevElement = null;
-    initialize();
+    configKey;
+
+    untrack(() => {
+      prevElement = null;
+      initialize();
+    });
 
     return () => {
       observer?.disconnect();

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -38,6 +38,10 @@
 
   let prevSkip = untrack(() => skip);
 
+  const configKey = $derived(
+    `${root}|${rootMargin}|${JSON.stringify(threshold)}`,
+  );
+
   const initialize = () => {
     observer = new IntersectionObserver(
       (entries) => {
@@ -70,8 +74,12 @@
   };
 
   $effect(() => {
-    prevElements = [];
-    initialize();
+    configKey;
+
+    untrack(() => {
+      prevElements = [];
+      initialize();
+    });
 
     return () => {
       observer?.disconnect();

--- a/tests/e2e/fixtures/ThresholdStableFixture.svelte
+++ b/tests/e2e/fixtures/ThresholdStableFixture.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { untrack } from "svelte";
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = $state(null);
+  let intersecting = $state(false);
+  let observer: null | IntersectionObserver = $state(null);
+  let observerCount = $state(0);
+  let unrelated = $state(0);
+
+  // A fresh array literal on every `unrelated` update, but always
+  // value-equal — this must not cause the underlying observer to be
+  // recreated.
+  let threshold = $derived([0, 0.5, unrelated * 0]);
+
+  $effect(() => {
+    if (observer) untrack(() => (observerCount += 1));
+  });
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="observer-count">Observer count: {observerCount}</p>
+  <button
+    data-testid="unrelated-button"
+    onclick={() => (unrelated += 1)}
+  >
+    Unrelated: {unrelated}
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  bind:observer
+  {threshold}
+>
+  <div bind:this={element}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: 100vh;
+    height: 100vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/threshold-stable.html
+++ b/tests/e2e/fixtures/threshold-stable.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Threshold Stable Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./threshold-stable.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/threshold-stable.ts
+++ b/tests/e2e/fixtures/threshold-stable.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import ThresholdStableFixture from "./ThresholdStableFixture.svelte";
+
+mount(ThresholdStableFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -103,6 +103,24 @@ test("Threshold - reinitializes the observer when changed at runtime", async ({
   await expect(page.locator("header")).toHaveText(/Element is not in view/);
 });
 
+test("Threshold - value-equal but referentially-new arrays do not recreate the observer", async ({
+  page,
+}) => {
+  await page.goto("/threshold-stable.html");
+
+  await expect(page.getByTestId("observer-count")).toHaveText(
+    /Observer count: 1/,
+  );
+
+  await page.getByTestId("unrelated-button").click();
+  await page.getByTestId("unrelated-button").click();
+  await page.getByTestId("unrelated-button").click();
+
+  await expect(page.getByTestId("observer-count")).toHaveText(
+    /Observer count: 1/,
+  );
+});
+
 test("Skip - pauses observing without losing state, resumes on toggle", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- `IntersectionObserver.svelte` and `MultipleIntersectionObserver.svelte` recreated the underlying `IntersectionObserver` whenever `root`/`rootMargin`/`threshold` changed by *reference*, even if the value was unchanged (e.g. a parent passing a fresh inline `threshold={[0, 0.5]}` array literal on every render). This tore down and rebuilt the observer unnecessarily on every parent re-render.
- Both components now memoize `root`/`rootMargin`/`threshold` into a value-based `configKey` (via `$derived`, mirroring the existing `intersect` action's `JSON.stringify` comparison), so the observer is only recreated when the config actually changes.
- The reinitialization effect reads `initialize()` inside `untrack(...)` so raw prop reads used only to construct the new `IntersectionObserver` don't themselves re-register as effect dependencies and defeat the memoization.

## Test plan
- [x] Added an e2e fixture/test (`Threshold - value-equal but referentially-new arrays do not recreate the observer`) asserting the observer identity is stable across renders with a fresh-but-equal `threshold` array
- [x] `bun test:e2e` — 27/27 passing
- [x] `bun test:types` — 0 errors
- [x] `biome check` — clean