### PR TITLE
fix(multiple-intersection-observer): unobserve elements when elements becomes empty

### DIFF
--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -84,27 +84,32 @@
     const isSkipped = skip;
     const activeObserver = observer;
 
-    if (currentElements.length > 0) {
-      const newElements = currentElements.filter(
-        (el) => el && !prevElements.includes(el),
-      );
+    const newElements = currentElements.filter(
+      (el) => el && !prevElements.includes(el),
+    );
+    const removedElements = prevElements.filter(
+      (el) => el && !currentElements.includes(el),
+    );
 
-      if (!isSkipped) {
-        for (const el of newElements) {
-          if (el) activeObserver?.observe(el);
-        }
+    if (!isSkipped) {
+      for (const el of newElements) {
+        if (el) activeObserver?.observe(el);
       }
-
-      const removedElements = prevElements.filter(
-        (el) => el && !currentElements.includes(el),
-      );
-
-      for (const el of removedElements) {
-        if (el) activeObserver?.unobserve(el);
-      }
-
-      prevElements = [...currentElements];
     }
+
+    for (const el of removedElements) {
+      if (!el) continue;
+      activeObserver?.unobserve(el);
+      elementIntersections.delete(el);
+      elementEntries.delete(el);
+    }
+
+    if (removedElements.length > 0) {
+      elementIntersections = new Map(elementIntersections);
+      elementEntries = new Map(elementEntries);
+    }
+
+    prevElements = [...currentElements];
 
     if (isSkipped !== prevSkip) {
       for (const el of currentElements) {

--- a/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
@@ -6,7 +6,10 @@
   let includeItem1 = true;
   let includeItem2 = false;
 
-  $: elements = [includeItem1 ? ref1 : null, includeItem2 ? ref2 : null];
+  $: elements = [
+    ...(includeItem1 ? [ref1] : []),
+    ...(includeItem2 ? [ref2] : []),
+  ];
 </script>
 
 <MultipleIntersectionObserver {elements}>
@@ -23,6 +26,18 @@
         onclick={() => (includeItem1 = false)}
       >
         Remove item 1
+      </button>
+      <button
+        data-testid="remove-item-2"
+        onclick={() => (includeItem2 = false)}
+      >
+        Remove item 2
+      </button>
+      <button
+        data-testid="add-item-1"
+        onclick={() => (includeItem1 = true)}
+      >
+        Add item 1
       </button>
       <p data-testid="item-1-status">
         {`Item 1 ${elementIntersections.get(ref1) ? "is visible" : "is not visible"}`}

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -454,6 +454,33 @@ test("Multiple elements - elements array add/remove retargets the observer", asy
     /Item 2 is not visible/,
   );
   await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+});
+
+test("Multiple elements - re-observes the same refs after elements becomes empty", async ({
+  page,
+}) => {
+  await page.goto("/multiple-elements-change.html");
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+
+  await page.getByTestId("remove-item-1").click();
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.getByTestId("add-item-1").click();
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is not visible/,
+  );
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
     /Item 1 is visible/,
   );
 });


### PR DESCRIPTION
## Summary
- The update effect in `MultipleIntersectionObserver.svelte` only diffed removed elements when the incoming `elements` array was non-empty. Clearing `elements` left every previously observed element still subscribed and `prevElements` stale, so repopulating with the same refs never re-observed them.
- Restructured the effect so the new/removed diff and `prevElements` update run unconditionally, and stale `elementIntersections`/`elementEntries` map entries are deleted for removed elements.

## Test plan
- [x] `bun test:types`
- [x] `bun test:e2e` (27/27 passing, including a new regression test: "Multiple elements - re-observes the same refs after elements becomes empty")