### PR TITLE
fix(intersection-observer): unobserve previous element when `element` becomes null

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -77,10 +77,15 @@
     const isSkipped = skip;
     const activeObserver = observer;
 
-    if (target !== null && target !== prevElement) {
-      if (!isSkipped) activeObserver?.observe(target);
+    if (target !== prevElement) {
       if (prevElement !== null) activeObserver?.unobserve(prevElement);
+      if (target !== null && !isSkipped) activeObserver?.observe(target);
       prevElement = target;
+
+      if (target === null) {
+        intersecting = false;
+        entry = null;
+      }
     }
 
     if (isSkipped !== prevSkip && target !== null) {

--- a/tests/e2e/fixtures/ElementNullFixture.svelte
+++ b/tests/e2e/fixtures/ElementNullFixture.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let ref: null | HTMLDivElement = null;
+  let includeElement = true;
+  let intersecting = false;
+
+  $: element = includeElement ? ref : null;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="clear"
+    onclick={() => (includeElement = false)}
+  >
+    Clear
+  </button>
+  <button
+    data-testid="restore"
+    onclick={() => (includeElement = true)}
+  >
+    Restore
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+>
+  <div bind:this={ref}>Hello world</div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  div {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+</style>

--- a/tests/e2e/fixtures/element-null.html
+++ b/tests/e2e/fixtures/element-null.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Element Null Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./element-null.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/element-null.ts
+++ b/tests/e2e/fixtures/element-null.ts
@@ -1,0 +1,4 @@
+import ElementNullFixture from "./ElementNullFixture.svelte";
+import { mount } from "./mount";
+
+mount(ElementNullFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -79,6 +79,29 @@ test("Element - switching the observed element retargets the observer", async ({
   await expect(page.locator("header")).toHaveText(/Element is in view/);
 });
 
+test("Element - unobserves when element becomes null and re-observes when restored", async ({
+  page,
+}) => {
+  await page.goto("/element-null.html");
+  const header = page.locator("header");
+
+  await expect(header).toHaveText(/Element is not in view/);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(header).toHaveText(/Element is in view/);
+
+  await page.getByTestId("clear").click();
+  await expect(header).toHaveText(/Element is not in view/);
+
+  // Scrolling away and back must not resurrect a leaked observation of the
+  // previous element.
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(header).toHaveText(/Element is not in view/);
+
+  await page.getByTestId("restore").click();
+  await expect(header).toHaveText(/Element is in view/);
+});
+
 test("Root margin - reinitializes the observer when changed at runtime", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- The runes-mode effect in `IntersectionObserver.svelte` skipped its unobserve/reset branch entirely whenever `element` was set to `null`, leaking the underlying `IntersectionObserver`'s subscription and leaving `intersecting`/`entry` stale.
- Worse, if the same element reference was restored after being cleared, the component would silently never re-observe it (since `prevElement` was never reset).
- The effect now unobserves the previous element regardless of whether the new target is null, and resets `intersecting`/`entry` when the target becomes null.

## Test plan
- [x] Added `tests/e2e/fixtures/ElementNullFixture.svelte` + `element-null.html`/`.ts`
- [x] Added a Playwright regression test asserting: immediate reset on `element = null`, no resurrected intersection state after scrolling away/back, and correct re-observation when the same element reference is restored
- [x] `bun test:types` passes
- [x] `bun test:e2e` passes (27/27)