### PR TITLE
feat: support IntersectionObserver v2 trackVisibility/delay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@
 
 Use it to lazy-load images, trigger scroll animations, implement infinite scroll, autoplay video when visible, track ad or analytics impressions, or detect when a user has scrolled to the end of a list.
 
+### Trustworthy impression tracking with `trackVisibility`
+
+By default, an element is reported as intersecting even if it's fully covered by another element (e.g. an overlay or iframe) — not something you want when billing an advertiser for an impression. Set `trackVisibility` to `true` (with a non-zero `delay`, per the underlying [Intersection Observer v2](https://developer.chrome.com/blog/intersectionobserver-v2/) spec) to get occlusion-aware visibility on `entry.isVisible`.
+
+```svelte
+<IntersectionObserver
+  {element}
+  trackVisibility
+  delay={100}
+  onintersect={(entry) => {
+    if (entry.isVisible) {
+      // Only fires when the element is unoccluded — safe to log an impression.
+    }
+  }}
+>
+  <div bind:this={element}>Ad content</div>
+</IntersectionObserver>
+```
+
 This zero-dependency library offers several ways to observe elements:
 
 - `IntersectionObserver`: component for observing a single element
@@ -396,6 +415,8 @@ As with the scroll-to-end example, `root` must be an element that scrolls on its
 | root         | Containing element                                          | `null` or `HTMLElement`                                                                                             | `null`        |
 | rootMargin   | Margin offset of the containing element                     | `string`                                                                                                            | `"0px"`       |
 | threshold    | Percentage of element visibility to trigger an event        | `number` between 0 and 1, or an array of `number`s between 0 and 1                                                  | `0`           |
+| trackVisibility | Enable occlusion-aware visibility tracking (Intersection Observer v2), populating `entry.isVisible`. Requires `delay` to be set. | `boolean`  | `false`       |
+| delay        | Minimum delay in milliseconds between notifications. Required to be non-zero when `trackVisibility` is `true`. | `number`                                                                       | `0`           |
 | entry        | Observed element metadata                                   | `null` or [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) | `null`        |
 | observer     | `IntersectionObserver` instance                             | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)           | `null`        |
 | skip         | Pause observing without losing `entry`/`intersecting` state | `boolean`                                                                                                           | `false`       |
@@ -428,6 +449,8 @@ Both callbacks are called with an [`IntersectionObserverEntry`](https://develope
 | root                 | Containing element                                    | `null` or `HTMLElement`                                                                                                                 | `null`        |
 | rootMargin           | Margin offset of the containing element               | `string`                                                                                                                                | `"0px"`       |
 | threshold            | Percentage of element visibility to trigger an event  | `number` between 0 and 1, or an array of `number`s between 0 and 1                                                                      | `0`           |
+| trackVisibility      | Enable occlusion-aware visibility tracking (Intersection Observer v2), populating `entry.isVisible`. Requires `delay` to be set. | `boolean` | `false`       |
+| delay                | Minimum delay in milliseconds between notifications. Required to be non-zero when `trackVisibility` is `true`. | `number`                                               | `0`           |
 | elementIntersections | Map of each element to its intersection state         | `Map<HTMLElement \| null, boolean>`                                                                                                     | `new Map()`   |
 | elementEntries       | Map of each element to its latest entry               | `Map<HTMLElement \| null,` [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry)`>` | `new Map()`   |
 | observer             | `IntersectionObserver` instance                       | `null` or [`IntersectionObserver`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)                               | `null`        |
@@ -466,6 +489,8 @@ Both callbacks are called with:
 | root       | Containing element                                       | `null` or `HTMLElement`                                            | `null`        |
 | rootMargin | Margin offset of the containing element                  | `string`                                                           | `"0px"`       |
 | threshold  | Percentage of element visibility to trigger an event     | `number` between 0 and 1, or an array of `number`s between 0 and 1 | `0`           |
+| trackVisibility | Enable occlusion-aware visibility tracking (Intersection Observer v2), populating `entry.isVisible`. Requires `delay` to be set. | `boolean` | `false` |
+| delay      | Minimum delay in milliseconds between notifications. Required to be non-zero when `trackVisibility` is `true`. | `number`         | `0`           |
 | once       | Unobserve the element after the first intersection event | `boolean`                                                          | `false`       |
 | skip       | Pause observing without disconnecting the observer       | `boolean`                                                          | `false`       |
 

--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -9,6 +9,8 @@
    * @property {null | HTMLElement} [root] Specify the containing element. Defaults to the browser viewport.
    * @property {string} [rootMargin] Margin offset of the containing element.
    * @property {number | number[]} [threshold] Percentage of element visibility to trigger an event. Value must be between 0 and 1.
+   * @property {boolean} [trackVisibility] Set to `true` to enable occlusion-aware visibility tracking (Intersection Observer v2), populating `entry.isVisible`. Requires `delay` to be set per the spec.
+   * @property {number} [delay] Minimum delay in milliseconds between notifications from the observer. Required to be non-zero when `trackVisibility` is `true`.
    * @property {null | IntersectionObserverEntry} [entry] Observed element metadata.
    * @property {null | IntersectionObserver} [observer] `IntersectionObserver` instance.
    * @property {boolean} [skip] Set to `true` to pause observing without disconnecting the observer or losing `entry`/`intersecting` state. Set back to `false` to resume.
@@ -25,6 +27,8 @@
     root = null,
     rootMargin = "0px",
     threshold = 0,
+    trackVisibility = false,
+    delay = 0,
     entry = $bindable(null),
     observer = $bindable(null),
     skip = false,
@@ -58,7 +62,7 @@
           }
         }
       },
-      { root, rootMargin, threshold },
+      { root, rootMargin, threshold, trackVisibility, delay },
     );
   };
 

--- a/src/IntersectionObserver.svelte.d.ts
+++ b/src/IntersectionObserver.svelte.d.ts
@@ -42,6 +42,21 @@ export interface IntersectionObserverProps {
   threshold?: number | number[];
 
   /**
+   * Set to `true` to enable occlusion-aware visibility tracking
+   * (Intersection Observer v2), populating `entry.isVisible`.
+   * Requires `delay` to be set per the spec.
+   * @default false
+   */
+  trackVisibility?: boolean;
+
+  /**
+   * Minimum delay in milliseconds between notifications from the
+   * observer. Required to be non-zero when `trackVisibility` is `true`.
+   * @default 0
+   */
+  delay?: number;
+
+  /**
    * Observed element metadata.
    * @default null
    */

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -8,6 +8,8 @@
    * @property {null | HTMLElement} [root] Specify the containing element. Defaults to the browser viewport.
    * @property {string} [rootMargin] Margin offset of the containing element.
    * @property {number | number[]} [threshold] Percentage of element visibility to trigger an event. Value must be between 0 and 1.
+   * @property {boolean} [trackVisibility] Set to `true` to enable occlusion-aware visibility tracking (Intersection Observer v2), populating `entry.isVisible`. Requires `delay` to be set per the spec.
+   * @property {number} [delay] Minimum delay in milliseconds between notifications from the observer. Required to be non-zero when `trackVisibility` is `true`.
    * @property {Map<HTMLElement | null, boolean>} [elementIntersections] Map of element to its intersection state.
    * @property {Map<HTMLElement | null, IntersectionObserverEntry>} [elementEntries] Map of element to its latest entry.
    * @property {null | IntersectionObserver} [observer] `IntersectionObserver` instance.
@@ -24,6 +26,8 @@
     root = null,
     rootMargin = "0px",
     threshold = 0,
+    trackVisibility = false,
+    delay = 0,
     elementIntersections = $bindable(new Map()),
     elementEntries = $bindable(new Map()),
     observer = $bindable(null),
@@ -65,7 +69,7 @@
         elementIntersections = new Map(elementIntersections);
         elementEntries = new Map(elementEntries);
       },
-      { root, rootMargin, threshold },
+      { root, rootMargin, threshold, trackVisibility, delay },
     );
   };
 

--- a/src/MultipleIntersectionObserver.svelte.d.ts
+++ b/src/MultipleIntersectionObserver.svelte.d.ts
@@ -36,6 +36,21 @@ export interface MultipleIntersectionObserverProps {
   threshold?: number | number[];
 
   /**
+   * Set to `true` to enable occlusion-aware visibility tracking
+   * (Intersection Observer v2), populating `entry.isVisible`.
+   * Requires `delay` to be set per the spec.
+   * @default false
+   */
+  trackVisibility?: boolean;
+
+  /**
+   * Minimum delay in milliseconds between notifications from the
+   * observer. Required to be non-zero when `trackVisibility` is `true`.
+   * @default 0
+   */
+  delay?: number;
+
+  /**
    * Map of element to its intersection state.
    * @default new Map()
    */

--- a/src/intersect.svelte.d.ts
+++ b/src/intersect.svelte.d.ts
@@ -23,6 +23,21 @@ export interface IntersectActionOptions {
   threshold?: number | number[];
 
   /**
+   * Set to `true` to enable occlusion-aware visibility tracking
+   * (Intersection Observer v2), populating `entry.isVisible`.
+   * Requires `delay` to be set per the spec.
+   * @default false
+   */
+  trackVisibility?: boolean;
+
+  /**
+   * Minimum delay in milliseconds between notifications from this
+   * observer. Required to be non-zero when `trackVisibility` is `true`.
+   * @default 0
+   */
+  delay?: number;
+
+  /**
    * Set to `true` to unobserve the element
    * after it intersects the viewport.
    * @default false
@@ -67,5 +82,18 @@ declare module "svelte/elements" {
     onintersect?: (
       event: CustomEvent<IntersectionObserverEntry & { isIntersecting: true }>,
     ) => void;
+  }
+}
+
+// TypeScript's DOM lib doesn't yet declare Intersection Observer v2
+// (`trackVisibility`/`delay`/`isVisible`), so it's added here.
+declare global {
+  interface IntersectionObserverInit {
+    trackVisibility?: boolean;
+    delay?: number;
+  }
+
+  interface IntersectionObserverEntry {
+    readonly isVisible: boolean;
   }
 }

--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -12,6 +12,8 @@ export function intersect(node, options = {}) {
     root = null,
     rootMargin = "0px",
     threshold = 0,
+    trackVisibility = false,
+    delay = 0,
     once = false,
     skip = false,
   } = options;
@@ -31,7 +33,7 @@ export function intersect(node, options = {}) {
           }
         }
       },
-      { root, rootMargin, threshold },
+      { root, rootMargin, threshold, trackVisibility, delay },
     );
 
   observer = createObserver();
@@ -47,12 +49,17 @@ export function intersect(node, options = {}) {
       const configChanged =
         (newOptions.root ?? null) !== root ||
         (newOptions.rootMargin ?? "0px") !== rootMargin ||
-        JSON.stringify(newOptions.threshold ?? 0) !== JSON.stringify(threshold);
+        JSON.stringify(newOptions.threshold ?? 0) !==
+          JSON.stringify(threshold) ||
+        (newOptions.trackVisibility ?? false) !== trackVisibility ||
+        (newOptions.delay ?? 0) !== delay;
 
       if (configChanged) {
         root = newOptions.root ?? null;
         rootMargin = newOptions.rootMargin ?? "0px";
         threshold = newOptions.threshold ?? 0;
+        trackVisibility = newOptions.trackVisibility ?? false;
+        delay = newOptions.delay ?? 0;
 
         observer.disconnect();
         observer = createObserver();

--- a/tests/e2e/fixtures/TrackVisibilityFixture.svelte
+++ b/tests/e2e/fixtures/TrackVisibilityFixture.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let intersecting = false;
+  let entry: null | IntersectionObserverEntry = null;
+  let occluded = true;
+
+  $: isVisible = entry?.isVisible ?? false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <p data-testid="visibility-status">
+    {isVisible ? "Element is visible" : "Element is not visible"}
+  </p>
+  <button
+    data-testid="toggle-occluder"
+    onclick={() => (occluded = !occluded)}
+  >
+    Toggle occluder
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  bind:entry
+  trackVisibility
+  delay={100}
+>
+  <div class="wrapper">
+    <div
+      bind:this={element}
+      class="target"
+    >
+      Hello world
+    </div>
+    {#if occluded}
+      <div
+        class="occluder"
+        data-testid="occluder"
+      ></div>
+    {/if}
+  </div>
+</IntersectionObserver>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  .wrapper {
+    position: relative;
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+  }
+
+  .target {
+    height: 100%;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+
+  .occluder {
+    position: absolute;
+    inset: 0;
+    background-color: #000;
+  }
+</style>

--- a/tests/e2e/fixtures/track-visibility.html
+++ b/tests/e2e/fixtures/track-visibility.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    >
+    <title>Track Visibility Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="./track-visibility.ts"
+    ></script>
+  </body>
+</html>

--- a/tests/e2e/fixtures/track-visibility.ts
+++ b/tests/e2e/fixtures/track-visibility.ts
@@ -1,0 +1,4 @@
+import { mount } from "./mount";
+import TrackVisibilityFixture from "./TrackVisibilityFixture.svelte";
+
+mount(TrackVisibilityFixture);

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -487,6 +487,33 @@ test("Multiple elements - basic pattern", async ({ page }) => {
   await expect(page.getByTestId("item-2-indicator")).toHaveText(/Item 2: ✗/);
 });
 
+test("Track visibility - entry.isVisible reflects occlusion, not just intersection", async ({
+  page,
+  browserName,
+}) => {
+  // Intersection Observer v2 (trackVisibility/isVisible) is only implemented
+  // in Chromium; skip elsewhere rather than flake on unsupported browsers.
+  test.skip(
+    browserName !== "chromium",
+    "trackVisibility is only supported in Chromium",
+  );
+
+  await page.goto("/track-visibility.html");
+  const header = page.locator("header");
+  const visibilityStatus = page.getByTestId("visibility-status");
+
+  await expect(header).toHaveText(/Element is not in view/);
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+  await expect(header).toHaveText(/Element is in view/);
+  await expect(visibilityStatus).toHaveText(/Element is not visible/);
+
+  await page.getByTestId("toggle-occluder").click();
+  await expect(visibilityStatus).toHaveText(/Element is visible/, {
+    timeout: 5_000,
+  });
+});
+
 test("Each block - bind:this + bind:intersecting per item does not deadlock and tracks independently", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- Adds `trackVisibility`/`delay` options across all three surfaces (`IntersectionObserver`, `MultipleIntersectionObserver`, `intersect`/`intersectAttachment`), enabling occlusion-aware visibility via `entry.isVisible` (Intersection Observer v2)
- Needed for trustworthy ad/analytics impression tracking, one of this library's stated use cases — without it, an element can report as intersecting even when fully covered by another element
- Augments TypeScript's DOM lib (which doesn't yet declare IO v2) so `trackVisibility`/`delay`/`entry.isVisible` type-check cleanly

## Test plan
- [x] `bun test:types` passes
- [x] `bun test:e2e` passes (27/27), including a new fixture that verifies `entry.isVisible` is `false` while the element is occluded and `true` once unoccluded (skipped on non-Chromium browsers, since IO v2 is Chromium-only)