### PR TITLE
test(multiple-intersection-observer): assert removed elements are deleted from intersection/entry maps

### DIFF
--- a/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleElementsChangeFixture.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <MultipleIntersectionObserver {elements}>
-  {#snippet children({ elementIntersections })}
+  {#snippet children({ elementIntersections, elementEntries })}
     <header>
       <button
         data-testid="add-item-2"
@@ -44,6 +44,9 @@
       </p>
       <p data-testid="item-2-status">
         {`Item 2 ${elementIntersections.get(ref2) ? "is visible" : "is not visible"}`}
+      </p>
+      <p data-testid="item-1-map-status">
+        {`Item 1 ${elementIntersections.has(ref1) || elementEntries.has(ref1) ? "is in maps" : "is not in maps"}`}
       </p>
     </header>
 

--- a/tests/e2e/intersection-observer.test.ts
+++ b/tests/e2e/intersection-observer.test.ts
@@ -494,8 +494,30 @@ test("Multiple elements - elements array add/remove retargets the observer", asy
   await expect(page.getByTestId("item-2-status")).toHaveText(
     /Item 2 is not visible/,
   );
+  // Item 1 was removed from `elements`, so its stale map entry is cleared
+  // rather than continuing to report its last-known intersection state.
   await expect(page.getByTestId("item-1-status")).toHaveText(
     /Item 1 is not visible/,
+  );
+});
+
+test("Multiple elements - removing an element clears its map entries", async ({
+  page,
+}) => {
+  await page.goto("/multiple-elements-change.html");
+
+  await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+  await expect(page.getByTestId("item-1-status")).toHaveText(
+    /Item 1 is visible/,
+  );
+  await expect(page.getByTestId("item-1-map-status")).toHaveText(
+    /Item 1 is in maps/,
+  );
+
+  await page.getByTestId("remove-item-1").click();
+
+  await expect(page.getByTestId("item-1-map-status")).toHaveText(
+    /Item 1 is not in maps/,
   );
 });
 


### PR DESCRIPTION
## Summary
- master already fixed the `elementIntersections`/`elementEntries` leak independently (#142) while this branch was in flight, so the source fix here is identical to master's and contributes nothing new.
- What's left: a test asserting `.has()` returns `false` for a removed element's key in both maps. The existing suite only checks `.get()` returning falsy, which can't distinguish "never observed" from "entry leaked but stale."

## Test plan
- [x] `bun test:types` — 0 errors
- [x] `bun test:e2e` — 30/30 passed