### PR TITLE
Strip JSDoc comments from packaged output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "svelte": "5.56.4",
         "svelte-check": "^4.7.1",
         "svelte-readme": "^4.3.0",
+        "typescript": "^5.9.3",
         "vite": "^8.1.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "svelte": "5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-readme": "^4.3.0",
+    "typescript": "^5.9.3",
     "vite": "^8.1.3"
   },
   "repository": {

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -1,4 +1,7 @@
+import { readdirSync } from "node:fs";
 import { $ } from "bun";
+import { parse } from "svelte/compiler";
+import ts from "typescript";
 
 console.time("package");
 
@@ -34,5 +37,92 @@ pkgJson.exports = {
 };
 
 await Bun.write("./package/package.json", JSON.stringify(pkgJson, null, 2));
+
+/** Comment ranges (byte offsets, delimiters included) found in a source string. */
+interface CommentRange {
+  start: number;
+  end: number;
+}
+
+function getJsCommentRanges(source: string): CommentRange[] {
+  const scanner = ts.createScanner(
+    ts.ScriptTarget.Latest,
+    /* skipTrivia */ false,
+    ts.LanguageVariant.Standard,
+    source,
+  );
+  const ranges: CommentRange[] = [];
+  let token = scanner.scan();
+  while (token !== ts.SyntaxKind.EndOfFileToken) {
+    if (
+      token === ts.SyntaxKind.SingleLineCommentTrivia ||
+      token === ts.SyntaxKind.MultiLineCommentTrivia
+    ) {
+      ranges.push({
+        start: scanner.getTokenStart(),
+        end: scanner.getTokenEnd(),
+      });
+    }
+    token = scanner.scan();
+  }
+  return ranges;
+}
+
+function getSvelteScriptCommentRanges(source: string): CommentRange[] {
+  const ast = parse(source, { modern: true });
+  return ast.comments.map((comment) => ({
+    start: comment.start,
+    end: comment.end,
+  }));
+}
+
+const WHITESPACE = /^[ \t]*$/;
+const isWhitespace = (text: string) => WHITESPACE.test(text);
+
+/** Removes the given comment ranges, dropping the whole line for standalone comments. */
+function stripComments(source: string, ranges: CommentRange[]): string {
+  let result = source;
+
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const { start, end } = ranges[i];
+    const lineStart = result.lastIndexOf("\n", start - 1) + 1;
+    const nextNewline = result.indexOf("\n", end);
+    const lineEnd = nextNewline === -1 ? result.length : nextNewline;
+
+    const before = result.slice(lineStart, start);
+    const after = result.slice(end, lineEnd);
+
+    if (isWhitespace(before) && isWhitespace(after)) {
+      // Comment is the only thing on the line: drop the whole line.
+      const deleteEnd = lineEnd < result.length ? lineEnd + 1 : lineEnd;
+      result = result.slice(0, lineStart) + result.slice(deleteEnd);
+    } else if (isWhitespace(before)) {
+      // Comment opens the line but code follows (e.g. a type-cast wrapping
+      // an expression): drop the leading indentation along with it.
+      result = result.slice(0, lineStart) + result.slice(end);
+    } else {
+      result = result.slice(0, start) + result.slice(end);
+    }
+  }
+
+  return result.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n");
+}
+
+await Promise.all(
+  readdirSync("./package").map(async (file) => {
+    const path = `./package/${file}`;
+
+    if (file.endsWith(".svelte")) {
+      const source = await Bun.file(path).text();
+      await Bun.write(
+        path,
+        stripComments(source, getSvelteScriptCommentRanges(source)),
+      );
+    } else if (file.endsWith(".js")) {
+      const source = await Bun.file(path).text();
+      await Bun.write(path, stripComments(source, getJsCommentRanges(source)));
+    }
+  }),
+);
 
 console.timeEnd("package");


### PR DESCRIPTION
## Summary
- `bun run package` now strips comments from the `.svelte`/`.js` implementation files it copies into `package/`, shrinking published bundle size (~43% smaller for these files) while keeping full JSDoc in `src/*` for editor DX and `svelte-check`.
- `.svelte` files are processed via `svelte/compiler`'s `parse()`, which returns exact comment ranges (`ast.comments`) — removal is AST-driven, not regex-based, so it can't be fooled by comment-like sequences inside strings/template literals.
- `.js` files are processed via the TypeScript scanner (`ts.createScanner`) for the same reason, since the svelte parser only understands `.svelte` markup.
- `.d.ts` files are left untouched — their JSDoc comments power hover/IntelliSense docs for consumers of the package.
- Added `typescript` as an explicit devDependency (previously only available transitively via `svelte-check`).

## Test plan
- [x] `bunx biome check scripts/npm-package.ts` passes with no errors
- [x] Packaged `.svelte` files still compile via `svelte/compiler`'s `compile()`
- [x] Packaged `.js` files pass `node --check`
- [x] Temporarily pointed the Playwright e2e config alias at the packaged output — all 26 e2e tests pass identically to `src`