### PR TITLE
Add Vitest unit test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   checks:
-    name: Lint & Type Check
+    name: Lint, Type Check & Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,6 +24,9 @@ jobs:
 
       - name: Check types
         run: bun run test:types
+
+      - name: Run unit tests
+        run: bun run test:unit
 
       - name: Build documentation
         run: bun run build

--- a/bun.lock
+++ b/bun.lock
@@ -9,15 +9,25 @@
         "@playwright/test": "^1.61.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@types/bun": "^1.3.14",
+        "jsdom": "^29.1.1",
         "svelte": "5.56.4",
         "svelte-check": "^4.7.1",
         "svelte-readme": "^4.3.0",
         "typescript": "^6.0.3",
         "vite": "^8.1.3",
+        "vitest": "^4.1.9",
       },
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
+
+    "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
     "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg=="],
@@ -36,11 +46,27 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
 
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.9", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.2.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.6", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.8", "", { "dependencies": { "@jridgewell/set-array": "^1.2.1", "@jridgewell/sourcemap-codec": "^1.4.10", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA=="],
 
@@ -92,6 +118,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
     "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
@@ -102,23 +130,55 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@22.13.0", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -126,15 +186,29 @@
 
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.0", "", {}, "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="],
+
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "esrap": ["esrap@2.2.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -162,13 +236,21 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -180,13 +262,25 @@
 
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "svelte": ["svelte@5.56.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw=="],
 
@@ -194,17 +288,51 @@
 
     "svelte-readme": ["svelte-readme@4.3.0", "", {}, "sha512-mtzW2Z9QNjRuH3c1I61ALEzK84wbJo24nY1Ao4qKymbe+7hwPOQqdXvCiGJ+a42WTE+mablgVPHCJKD4Jv0WTg=="],
 
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tldts": ["tldts@7.4.6", "", { "dependencies": { "tldts-core": "^7.4.6" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q=="],
+
+    "tldts-core": ["tldts-core@7.4.6", "", {}, "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA=="],
+
+    "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 
     "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "@playwright/test": "^1.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/bun": "^1.3.14",
+    "jsdom": "^29.1.1",
     "svelte": "5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-readme": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^8.1.3"
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "package": "bun scripts/npm-package.ts",
     "test:types": "svelte-check --workspace tests",
+    "test:unit": "vitest run",
     "test:e2e": "playwright test",
     "lint": "biome check --write .",
     "lint:changed": "biome check --write --changed --since=master --no-errors-on-unmatched ."

--- a/tests/unit/IntersectionObserver.test.ts
+++ b/tests/unit/IntersectionObserver.test.ts
@@ -1,0 +1,213 @@
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, test } from "vitest";
+import BasicFixture from "../e2e/fixtures/BasicFixture.svelte";
+import EachBindingFixture from "../e2e/fixtures/EachBindingFixture.svelte";
+import ElementChangeFixture from "../e2e/fixtures/ElementChangeFixture.svelte";
+import OnceFixture from "../e2e/fixtures/OnceFixture.svelte";
+import RootFixture from "../e2e/fixtures/RootFixture.svelte";
+import RootMarginChangeFixture from "../e2e/fixtures/RootMarginChangeFixture.svelte";
+import RootMarginFixture from "../e2e/fixtures/RootMarginFixture.svelte";
+import SkipFixture from "../e2e/fixtures/SkipFixture.svelte";
+import ThresholdChangeFixture from "../e2e/fixtures/ThresholdChangeFixture.svelte";
+import ThresholdFixture from "../e2e/fixtures/ThresholdFixture.svelte";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+import { render } from "./render";
+
+// These fixtures are shared with the Playwright e2e suite (real scroll,
+// real browser). Reusing them here — driven by a mocked IntersectionObserver
+// instead of real geometry — covers the reactive wiring around the observer
+// (observe/unobserve, effect cleanup, prop syncing) fast and deterministically.
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("IntersectionObserver", () => {
+  test("reflects intersecting state via bind:intersecting", () => {
+    const rendered = render(BasicFixture);
+    cleanup = rendered.cleanup;
+    const header = rendered.target.querySelector("header");
+    const el = rendered.target.querySelector("div");
+    if (!header || !el) throw new Error("fixture markup missing");
+
+    expect(header.textContent).toContain("Element is not in view");
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(el)).toBe(true);
+
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: true }]));
+    expect(header.textContent).toContain("Element is in view");
+
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: false }]));
+    expect(header.textContent).toContain("Element is not in view");
+  });
+
+  test("once unobserves the element after it intersects and ignores unrelated updates", () => {
+    const rendered = render(OnceFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    if (!el) throw new Error("fixture markup missing");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: true }]));
+
+    expect(observer.observedElements.has(el)).toBe(false);
+    expect(
+      rendered.target.querySelector('[data-testid="intersect-count"]')
+        ?.textContent,
+    ).toContain("Intersect count: 1");
+
+    const unrelatedButton = rendered.target.querySelector(
+      '[data-testid="unrelated-button"]',
+    );
+    if (!(unrelatedButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    for (let i = 0; i < 3; i++) {
+      unrelatedButton.click();
+      flushSync();
+    }
+
+    expect(
+      rendered.target.querySelector('[data-testid="intersect-count"]')
+        ?.textContent,
+    ).toContain("Intersect count: 1");
+  });
+
+  test("skip pauses and resumes observation without losing state", () => {
+    const rendered = render(SkipFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const toggle = rendered.target.querySelector('[data-testid="toggle-skip"]');
+    if (!el || !(toggle instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(el)).toBe(true);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(el)).toBe(false);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(el)).toBe(true);
+  });
+
+  test("switching the observed element unobserves the old one and observes the new one", () => {
+    const rendered = render(ElementChangeFixture);
+    cleanup = rendered.cleanup;
+    const elementA = rendered.target.querySelector('[data-testid="element-a"]');
+    const elementB = rendered.target.querySelector('[data-testid="element-b"]');
+    const switchButton = rendered.target.querySelector(
+      '[data-testid="switch"]',
+    );
+    if (
+      !elementA ||
+      !elementB ||
+      !(switchButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(elementA)).toBe(true);
+    expect(observer.observedElements.has(elementB)).toBe(false);
+
+    switchButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(observer.observedElements.has(elementA)).toBe(false);
+    expect(observer.observedElements.has(elementB)).toBe(true);
+  });
+
+  test("changing threshold recreates the observer and re-observes the current element", () => {
+    const rendered = render(ThresholdChangeFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const raiseButton = rendered.target.querySelector(
+      '[data-testid="raise-threshold"]',
+    );
+    if (!el || !(raiseButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const firstObserver = MockIntersectionObserver.last();
+    raiseButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(firstObserver.disconnected).toBe(true);
+
+    const secondObserver = MockIntersectionObserver.last();
+    expect(secondObserver.options.threshold).toBe(0.99);
+    expect(secondObserver.observedElements.has(el)).toBe(true);
+  });
+
+  test("changing rootMargin recreates the observer", () => {
+    const rendered = render(RootMarginChangeFixture);
+    cleanup = rendered.cleanup;
+    const shrinkButton = rendered.target.querySelector(
+      '[data-testid="shrink-root-margin"]',
+    );
+    if (!(shrinkButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    shrinkButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(MockIntersectionObserver.last().options.rootMargin).toBe("-200px");
+  });
+
+  test("passes root/rootMargin/threshold through to the underlying observer", () => {
+    const threshold = render(ThresholdFixture);
+    cleanup = threshold.cleanup;
+    expect(MockIntersectionObserver.last().options.threshold).toBe(0.5);
+    threshold.cleanup();
+
+    const rootMargin = render(RootMarginFixture);
+    cleanup = rootMargin.cleanup;
+    expect(MockIntersectionObserver.last().options.rootMargin).toBe("-200px");
+  });
+
+  test("root scopes observation to a containing element", () => {
+    const rendered = render(RootFixture);
+    cleanup = rendered.cleanup;
+    const container = rendered.target.querySelector(
+      '[data-testid="container"]',
+    );
+    if (!container) throw new Error("fixture markup missing");
+
+    expect(MockIntersectionObserver.last().options.root).toBe(container);
+  });
+
+  test("each block instances get independent observers", () => {
+    const rendered = render(EachBindingFixture);
+    cleanup = rendered.cleanup;
+
+    expect(MockIntersectionObserver.instances).toHaveLength(3);
+
+    const sectionOne = rendered.target.querySelector(
+      '[data-testid="section-one"]',
+    );
+    if (!sectionOne) throw new Error("fixture markup missing");
+
+    const observerOne = MockIntersectionObserver.instances[0];
+    flushSync(() =>
+      observerOne.trigger([{ target: sectionOne, isIntersecting: true }]),
+    );
+
+    expect(sectionOne.textContent).toContain("visible");
+    expect(
+      rendered.target.querySelector('[data-testid="section-two"]')?.textContent,
+    ).toContain("not visible");
+  });
+});

--- a/tests/unit/IntersectionObserver.test.ts
+++ b/tests/unit/IntersectionObserver.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "vitest";
 import BasicFixture from "../e2e/fixtures/BasicFixture.svelte";
 import EachBindingFixture from "../e2e/fixtures/EachBindingFixture.svelte";
 import ElementChangeFixture from "../e2e/fixtures/ElementChangeFixture.svelte";
+import ElementNullFixture from "../e2e/fixtures/ElementNullFixture.svelte";
 import OnceFixture from "../e2e/fixtures/OnceFixture.svelte";
 import RootFixture from "../e2e/fixtures/RootFixture.svelte";
 import RootMarginChangeFixture from "../e2e/fixtures/RootMarginChangeFixture.svelte";
@@ -10,6 +11,7 @@ import RootMarginFixture from "../e2e/fixtures/RootMarginFixture.svelte";
 import SkipFixture from "../e2e/fixtures/SkipFixture.svelte";
 import ThresholdChangeFixture from "../e2e/fixtures/ThresholdChangeFixture.svelte";
 import ThresholdFixture from "../e2e/fixtures/ThresholdFixture.svelte";
+import ThresholdStableFixture from "../e2e/fixtures/ThresholdStableFixture.svelte";
 import { MockIntersectionObserver } from "./mock-intersection-observer";
 import { render } from "./render";
 
@@ -209,5 +211,64 @@ describe("IntersectionObserver", () => {
     expect(
       rendered.target.querySelector('[data-testid="section-two"]')?.textContent,
     ).toContain("not visible");
+  });
+
+  test("element becoming null unobserves it and resets intersecting/entry; restoring re-observes", () => {
+    const rendered = render(ElementNullFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const header = rendered.target.querySelector("header");
+    const clearButton = rendered.target.querySelector('[data-testid="clear"]');
+    const restoreButton = rendered.target.querySelector(
+      '[data-testid="restore"]',
+    );
+    if (
+      !el ||
+      !header ||
+      !(clearButton instanceof HTMLButtonElement) ||
+      !(restoreButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: true }]));
+    expect(header.textContent).toContain("Element is in view");
+
+    clearButton.click();
+    flushSync();
+
+    expect(observer.observedElements.has(el)).toBe(false);
+    expect(header.textContent).toContain("Element is not in view");
+
+    restoreButton.click();
+    flushSync();
+    expect(observer.observedElements.has(el)).toBe(true);
+  });
+
+  test("value-equal but referentially-new threshold arrays do not recreate the observer", () => {
+    const rendered = render(ThresholdStableFixture);
+    cleanup = rendered.cleanup;
+    const unrelatedButton = rendered.target.querySelector(
+      '[data-testid="unrelated-button"]',
+    );
+    if (!(unrelatedButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    expect(
+      rendered.target.querySelector('[data-testid="observer-count"]')
+        ?.textContent,
+    ).toContain("Observer count: 1");
+
+    for (let i = 0; i < 3; i++) {
+      unrelatedButton.click();
+      flushSync();
+    }
+
+    expect(
+      rendered.target.querySelector('[data-testid="observer-count"]')
+        ?.textContent,
+    ).toContain("Observer count: 1");
   });
 });

--- a/tests/unit/MultipleIntersectionObserver.test.ts
+++ b/tests/unit/MultipleIntersectionObserver.test.ts
@@ -147,6 +147,42 @@ describe("MultipleIntersectionObserver", () => {
     expect(MockIntersectionObserver.instances).toHaveLength(1);
   });
 
+  test("removing the only element empties the array, unobserves it, and clears map entries; re-adding it re-observes", () => {
+    const rendered = render(MultipleElementsChangeFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const removeButton = rendered.target.querySelector(
+      '[data-testid="remove-item-1"]',
+    );
+    const addButton = rendered.target.querySelector(
+      '[data-testid="add-item-1"]',
+    );
+    if (
+      !item1 ||
+      !(removeButton instanceof HTMLButtonElement) ||
+      !(addButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(item1)).toBe(true);
+
+    removeButton.click();
+    flushSync();
+
+    expect(observer.observedElements.has(item1)).toBe(false);
+    expect(
+      rendered.target.querySelector('[data-testid="item-1-map-status"]')
+        ?.textContent,
+    ).toContain("Item 1 is not in maps");
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    addButton.click();
+    flushSync();
+    expect(observer.observedElements.has(item1)).toBe(true);
+  });
+
   test("once unobserves only the target that intersected", () => {
     const rendered = render(MultipleOnceFixture);
     cleanup = rendered.cleanup;

--- a/tests/unit/MultipleIntersectionObserver.test.ts
+++ b/tests/unit/MultipleIntersectionObserver.test.ts
@@ -1,0 +1,228 @@
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, test } from "vitest";
+import MultipleBasicFixture from "../e2e/fixtures/MultipleBasicFixture.svelte";
+import MultipleBindingFixture from "../e2e/fixtures/MultipleBindingFixture.svelte";
+import MultipleElementsChangeFixture from "../e2e/fixtures/MultipleElementsChangeFixture.svelte";
+import MultipleFixture from "../e2e/fixtures/MultipleFixture.svelte";
+import MultipleOnceFixture from "../e2e/fixtures/MultipleOnceFixture.svelte";
+import MultipleRootFixture from "../e2e/fixtures/MultipleRootFixture.svelte";
+import MultipleRootMarginChangeFixture from "../e2e/fixtures/MultipleRootMarginChangeFixture.svelte";
+import MultipleSkipFixture from "../e2e/fixtures/MultipleSkipFixture.svelte";
+import MultipleThresholdFixture from "../e2e/fixtures/MultipleThresholdFixture.svelte";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+import { render } from "./render";
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("MultipleIntersectionObserver", () => {
+  test("uses a single observer for all elements and tracks each independently", () => {
+    const rendered = render(MultipleBasicFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    if (!item1 || !item2) throw new Error("fixture markup missing");
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(item1)).toBe(true);
+    expect(observer.observedElements.has(item2)).toBe(true);
+
+    flushSync(() =>
+      observer.trigger([{ target: item1, isIntersecting: true }]),
+    );
+
+    expect(
+      rendered.target.querySelector('[data-testid="item-1-indicator"]')
+        ?.textContent,
+    ).toContain("✓");
+    expect(
+      rendered.target.querySelector('[data-testid="item-2-indicator"]')
+        ?.textContent,
+    ).toContain("✗");
+  });
+
+  test("batches multiple entries from the same callback into one reactive update", () => {
+    const rendered = render(MultipleFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    const item3 = rendered.target.querySelector('[data-testid="item-3"]');
+    if (!item1 || !item2 || !item3) throw new Error("fixture markup missing");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() =>
+      observer.trigger([
+        { target: item1, isIntersecting: true },
+        { target: item2, isIntersecting: false },
+        { target: item3, isIntersecting: true },
+      ]),
+    );
+
+    expect(
+      rendered.target.querySelector('[data-testid="item-1-status"]')
+        ?.textContent,
+    ).toContain("Item 1 is visible");
+    expect(
+      rendered.target.querySelector('[data-testid="item-2-status"]')
+        ?.textContent,
+    ).toContain("Item 2 is not visible");
+    expect(
+      rendered.target.querySelector('[data-testid="item-3-status"]')
+        ?.textContent,
+    ).toContain("Item 3 is visible");
+  });
+
+  test("passes threshold through to the underlying observer", () => {
+    const rendered = render(MultipleThresholdFixture);
+    cleanup = rendered.cleanup;
+    expect(MockIntersectionObserver.last().options.threshold).toBe(0.5);
+  });
+
+  test("bind:elementIntersections exposes reactive state to the parent", () => {
+    const rendered = render(MultipleBindingFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    if (!item1) throw new Error("fixture markup missing");
+
+    expect(
+      rendered.target
+        .querySelector('[data-testid="header"]')
+        ?.getAttribute("data-any-visible"),
+    ).toBe("false");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() =>
+      observer.trigger([{ target: item1, isIntersecting: true }]),
+    );
+
+    expect(
+      rendered.target
+        .querySelector('[data-testid="header"]')
+        ?.getAttribute("data-any-visible"),
+    ).toBe("true");
+    expect(
+      rendered.target
+        .querySelector('[data-testid="item-1"]')
+        ?.getAttribute("data-visible"),
+    ).toBe("true");
+  });
+
+  test("adding and removing elements updates observation without recreating the observer", () => {
+    const rendered = render(MultipleElementsChangeFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    const addButton = rendered.target.querySelector(
+      '[data-testid="add-item-2"]',
+    );
+    const removeButton = rendered.target.querySelector(
+      '[data-testid="remove-item-1"]',
+    );
+    if (
+      !item1 ||
+      !item2 ||
+      !(addButton instanceof HTMLButtonElement) ||
+      !(removeButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(item1)).toBe(true);
+    expect(observer.observedElements.has(item2)).toBe(false);
+
+    addButton.click();
+    flushSync();
+    expect(observer.observedElements.has(item2)).toBe(true);
+
+    removeButton.click();
+    flushSync();
+    expect(observer.observedElements.has(item1)).toBe(false);
+    expect(observer.observedElements.has(item2)).toBe(true);
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+  });
+
+  test("once unobserves only the target that intersected", () => {
+    const rendered = render(MultipleOnceFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    if (!item1 || !item2) throw new Error("fixture markup missing");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() =>
+      observer.trigger([{ target: item1, isIntersecting: true }]),
+    );
+
+    expect(observer.observedElements.has(item1)).toBe(false);
+    expect(observer.observedElements.has(item2)).toBe(true);
+    expect(
+      rendered.target.querySelector('[data-testid="item-1-count"]')
+        ?.textContent,
+    ).toContain("Item 1 intersect count: 1");
+    expect(
+      rendered.target.querySelector('[data-testid="item-2-count"]')
+        ?.textContent,
+    ).toContain("Item 2 intersect count: 0");
+  });
+
+  test("root scopes observation to a containing element", () => {
+    const rendered = render(MultipleRootFixture);
+    cleanup = rendered.cleanup;
+    const container = rendered.target.querySelector(
+      '[data-testid="container"]',
+    );
+    if (!container) throw new Error("fixture markup missing");
+
+    expect(MockIntersectionObserver.last().options.root).toBe(container);
+  });
+
+  test("changing rootMargin recreates the observer and re-observes current elements", () => {
+    const rendered = render(MultipleRootMarginChangeFixture);
+    cleanup = rendered.cleanup;
+    const shrinkButton = rendered.target.querySelector(
+      '[data-testid="shrink-root-margin"]',
+    );
+    if (!(shrinkButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const firstObserver = MockIntersectionObserver.last();
+    shrinkButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(firstObserver.disconnected).toBe(true);
+    expect(MockIntersectionObserver.last().options.rootMargin).toBe("-200px");
+  });
+
+  test("skip pauses and resumes observation of all elements", () => {
+    const rendered = render(MultipleSkipFixture);
+    cleanup = rendered.cleanup;
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    const toggle = rendered.target.querySelector('[data-testid="toggle-skip"]');
+    if (!item1 || !item2 || !(toggle instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(item1)).toBe(true);
+    expect(observer.observedElements.has(item2)).toBe(true);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(item1)).toBe(false);
+    expect(observer.observedElements.has(item2)).toBe(false);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(item1)).toBe(true);
+    expect(observer.observedElements.has(item2)).toBe(true);
+  });
+});

--- a/tests/unit/create-intersection-group.test.ts
+++ b/tests/unit/create-intersection-group.test.ts
@@ -1,0 +1,175 @@
+import { flushSync } from "svelte";
+import { createIntersectionGroup } from "svelte-intersection-observer";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import IntersectionGroupFixture from "../e2e/fixtures/IntersectionGroupFixture.svelte";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+import { render } from "./render";
+
+// `group.attach(...)` returns a plain `(node) => cleanup` function — unlike
+// `intersectAttachment`, it doesn't go through `fromAction`'s render-effect
+// plumbing, so the core logic is testable directly without mounting a
+// component.
+describe("createIntersectionGroup", () => {
+  test("lazily creates one shared observer across multiple attach() calls", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+    const nodeB = document.createElement("div");
+
+    expect(MockIntersectionObserver.instances).toHaveLength(0);
+
+    group.attach()(nodeA);
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    group.attach()(nodeB);
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(nodeA)).toBe(true);
+    expect(observer.observedElements.has(nodeB)).toBe(true);
+  });
+
+  test("skip prevents the initial observe for that node only", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+    const nodeB = document.createElement("div");
+
+    group.attach({ skip: true })(nodeA);
+    group.attach()(nodeB);
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(nodeA)).toBe(false);
+    expect(observer.observedElements.has(nodeB)).toBe(true);
+  });
+
+  test("dispatches onobserve/onintersect only to the matching node's callbacks", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+    const nodeB = document.createElement("div");
+
+    const observeA = vi.fn();
+    const intersectA = vi.fn();
+    const observeB = vi.fn();
+
+    group.attach({ onobserve: observeA, onintersect: intersectA })(nodeA);
+    group.attach({ onobserve: observeB })(nodeB);
+
+    const observer = MockIntersectionObserver.last();
+    observer.trigger([
+      { target: nodeA, isIntersecting: true },
+      { target: nodeB, isIntersecting: false },
+    ]);
+
+    expect(observeA).toHaveBeenCalledTimes(1);
+    expect(intersectA).toHaveBeenCalledTimes(1);
+    expect(observeB).toHaveBeenCalledTimes(1);
+  });
+
+  test("once unobserves only the node that intersected", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+    const nodeB = document.createElement("div");
+
+    group.attach({ once: true })(nodeA);
+    group.attach()(nodeB);
+
+    const observer = MockIntersectionObserver.last();
+    observer.trigger([{ target: nodeA, isIntersecting: true }]);
+
+    expect(observer.observedElements.has(nodeA)).toBe(false);
+    expect(observer.observedElements.has(nodeB)).toBe(true);
+  });
+
+  test("detaching one node unobserves it without tearing down the shared observer", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+    const nodeB = document.createElement("div");
+
+    const detachA = group.attach()(nodeA);
+    group.attach()(nodeB);
+
+    const observer = MockIntersectionObserver.last();
+    detachA?.();
+
+    expect(observer.observedElements.has(nodeA)).toBe(false);
+    expect(observer.observedElements.has(nodeB)).toBe(true);
+    expect(observer.disconnected).toBe(false);
+  });
+
+  test("detaching the last node disconnects the observer; the next attach() creates a fresh one", () => {
+    const group = createIntersectionGroup();
+    const nodeA = document.createElement("div");
+
+    const detachA = group.attach()(nodeA);
+    const firstObserver = MockIntersectionObserver.last();
+
+    detachA?.();
+    expect(firstObserver.disconnected).toBe(true);
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    const nodeB = document.createElement("div");
+    group.attach()(nodeB);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(MockIntersectionObserver.last()).not.toBe(firstObserver);
+  });
+
+  test("shared options are read once, when the observer is (re)created — not reactively", () => {
+    let rootMargin = "0px";
+    const group = createIntersectionGroup(() => ({ rootMargin }));
+    const nodeA = document.createElement("div");
+
+    const detachA = group.attach()(nodeA);
+    expect(MockIntersectionObserver.last().options.rootMargin).toBe("0px");
+
+    // The group already has a live observer; changing what the options
+    // function returns must not retroactively reconfigure it.
+    rootMargin = "-200px";
+    detachA?.();
+
+    const nodeB = document.createElement("div");
+    group.attach()(nodeB);
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(MockIntersectionObserver.last().options.rootMargin).toBe("-200px");
+  });
+});
+
+describe("createIntersectionGroup (component integration)", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  test("shares a single observer across #each items and dispatches per-node callbacks", () => {
+    const rendered = render(IntersectionGroupFixture);
+    cleanup = rendered.cleanup;
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    if (!item2) throw new Error("fixture markup missing");
+
+    expect(
+      rendered.target.querySelector('[data-testid="observer-count"]')
+        ?.textContent,
+    ).toContain("Observer count: 1");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() =>
+      observer.trigger([{ target: item2, isIntersecting: true }]),
+    );
+
+    expect(
+      rendered.target.querySelector('[data-testid="item-1-status"]')
+        ?.textContent,
+    ).toContain("Item 1 is not visible");
+    expect(
+      rendered.target.querySelector('[data-testid="item-2-status"]')
+        ?.textContent,
+    ).toContain("Item 2 is visible");
+
+    expect(
+      rendered.target.querySelector('[data-testid="observer-count"]')
+        ?.textContent,
+    ).toContain("Observer count: 1");
+  });
+});

--- a/tests/unit/create-intersection-observer.test.ts
+++ b/tests/unit/create-intersection-observer.test.ts
@@ -1,0 +1,43 @@
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, test } from "vitest";
+import CreateIntersectionObserverFixture from "../e2e/fixtures/CreateIntersectionObserverFixture.svelte";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+import { render } from "./render";
+
+// createIntersectionObserver wraps intersectAttachment, so — like
+// intersectAttachment — it can only be exercised inside a mounted component
+// (see intersect-component.test.ts).
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("createIntersectionObserver", () => {
+  test("exposes intersecting/entry reactively via {@attach observer.attach} and honors once", () => {
+    const rendered = render(CreateIntersectionObserverFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const header = rendered.target.querySelector("header");
+    if (!el || !header) throw new Error("fixture markup missing");
+
+    expect(header.textContent).toContain("Element is not in view");
+    expect(
+      rendered.target.querySelector('[data-testid="intersect-count"]')
+        ?.textContent,
+    ).toContain("Intersect count: 0");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: true }]));
+
+    expect(header.textContent).toContain("Element is in view");
+    expect(
+      rendered.target.querySelector('[data-testid="intersect-count"]')
+        ?.textContent,
+    ).toContain("Intersect count: 1");
+    // `once: true` in the fixture
+    expect(observer.observedElements.has(el)).toBe(false);
+  });
+});

--- a/tests/unit/intersect-action.test.ts
+++ b/tests/unit/intersect-action.test.ts
@@ -1,0 +1,130 @@
+import { intersect } from "svelte-intersection-observer";
+import { describe, expect, test, vi } from "vitest";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+
+/** `intersect()` always returns handlers; narrow away the `Action` type's `void` branch. */
+function handlers<T>(action: T): Exclude<T, void> {
+  if (!action) throw new Error("intersect() should always return handlers");
+  return action as Exclude<T, void>;
+}
+
+describe("intersect action", () => {
+  test("observes the node with default options", () => {
+    const node = document.createElement("div");
+    intersect(node);
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.options).toEqual({
+      root: null,
+      rootMargin: "0px",
+      threshold: 0,
+    });
+    expect(observer.observedElements.has(node)).toBe(true);
+  });
+
+  test("does not observe when skip is true", () => {
+    const node = document.createElement("div");
+    intersect(node, { skip: true });
+
+    expect(MockIntersectionObserver.last().observedElements.has(node)).toBe(
+      false,
+    );
+  });
+
+  test("dispatches observe on every callback and intersect only when intersecting", () => {
+    const node = document.createElement("div");
+    intersect(node);
+
+    const observeSpy = vi.fn();
+    const intersectSpy = vi.fn();
+    node.addEventListener("observe", observeSpy);
+    node.addEventListener("intersect", intersectSpy);
+
+    const observer = MockIntersectionObserver.last();
+    observer.trigger([{ target: node, isIntersecting: false }]);
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+    expect(intersectSpy).not.toHaveBeenCalled();
+
+    observer.trigger([{ target: node, isIntersecting: true }]);
+    expect(observeSpy).toHaveBeenCalledTimes(2);
+    expect(intersectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("once unobserves the node after it intersects", () => {
+    const node = document.createElement("div");
+    intersect(node, { once: true });
+
+    const observer = MockIntersectionObserver.last();
+    observer.trigger([{ target: node, isIntersecting: true }]);
+
+    expect(observer.observedElements.has(node)).toBe(false);
+  });
+
+  test("without once, the node stays observed after intersecting", () => {
+    const node = document.createElement("div");
+    intersect(node);
+
+    const observer = MockIntersectionObserver.last();
+    observer.trigger([{ target: node, isIntersecting: true }]);
+
+    expect(observer.observedElements.has(node)).toBe(true);
+  });
+
+  test("update() with an unchanged config just toggles skip on the same observer", () => {
+    const node = document.createElement("div");
+    const action = handlers(intersect(node, {}));
+
+    const observer = MockIntersectionObserver.last();
+    action.update?.({ skip: true });
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+    expect(observer.observedElements.has(node)).toBe(false);
+
+    action.update?.({ skip: false });
+    expect(observer.observedElements.has(node)).toBe(true);
+  });
+
+  test("update() with a changed root/rootMargin/threshold recreates the observer", () => {
+    const node = document.createElement("div");
+    const action = handlers(intersect(node, { rootMargin: "0px" }));
+
+    const firstObserver = MockIntersectionObserver.last();
+    action.update?.({ rootMargin: "-200px" });
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(firstObserver.disconnected).toBe(true);
+
+    const secondObserver = MockIntersectionObserver.last();
+    expect(secondObserver).not.toBe(firstObserver);
+    expect(secondObserver.options.rootMargin).toBe("-200px");
+    expect(secondObserver.observedElements.has(node)).toBe(true);
+  });
+
+  test("update() does not recreate the observer when a threshold array is unchanged by value", () => {
+    const node = document.createElement("div");
+    const action = handlers(intersect(node, { threshold: [0, 0.5] }));
+
+    action.update?.({ threshold: [0, 0.5] });
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+  });
+
+  test("update() skips re-observing a recreated observer when newSkip is true", () => {
+    const node = document.createElement("div");
+    const action = handlers(intersect(node, { rootMargin: "0px" }));
+
+    action.update?.({ rootMargin: "-200px", skip: true });
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(node)).toBe(false);
+  });
+
+  test("destroy() disconnects the observer", () => {
+    const node = document.createElement("div");
+    const action = handlers(intersect(node));
+
+    action.destroy?.();
+
+    expect(MockIntersectionObserver.last().disconnected).toBe(true);
+  });
+});

--- a/tests/unit/intersect-component.test.ts
+++ b/tests/unit/intersect-component.test.ts
@@ -1,0 +1,103 @@
+import { flushSync } from "svelte";
+import { afterEach, describe, expect, test } from "vitest";
+import ActionFixture from "../e2e/fixtures/ActionFixture.svelte";
+import ActionRootMarginChangeFixture from "../e2e/fixtures/ActionRootMarginChangeFixture.svelte";
+import ActionSkipFixture from "../e2e/fixtures/ActionSkipFixture.svelte";
+import AttachmentFixture from "../e2e/fixtures/AttachmentFixture.svelte";
+import AttachmentRootMarginChangeFixture from "../e2e/fixtures/AttachmentRootMarginChangeFixture.svelte";
+import AttachmentSkipFixture from "../e2e/fixtures/AttachmentSkipFixture.svelte";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+import { render } from "./render";
+
+// `intersectAttachment` is a thin `fromAction` wrapper around `intersect`, and
+// `fromAction`'s returned function relies on Svelte's internal render-effect
+// plumbing — it can only be exercised inside a mounted component, unlike the
+// plain-function `intersect` action tested in intersect-action.test.ts.
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe.each([
+  {
+    name: "use:intersect",
+    Fixture: ActionFixture,
+    SkipFixture: ActionSkipFixture,
+    RootMarginChangeFixture: ActionRootMarginChangeFixture,
+  },
+  {
+    name: "{@attach intersectAttachment}",
+    Fixture: AttachmentFixture,
+    SkipFixture: AttachmentSkipFixture,
+    RootMarginChangeFixture: AttachmentRootMarginChangeFixture,
+  },
+])("$name", ({ Fixture, SkipFixture, RootMarginChangeFixture }) => {
+  test("onobserve/onintersect fire from dispatched events and once behavior applies", () => {
+    const rendered = render(Fixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    if (!el) throw new Error("fixture markup missing");
+
+    const header = rendered.target.querySelector("header");
+    expect(header?.textContent).toContain("Element is not in view");
+
+    const observer = MockIntersectionObserver.last();
+    flushSync(() => observer.trigger([{ target: el, isIntersecting: true }]));
+
+    expect(header?.textContent).toContain("Element is in view");
+    expect(
+      rendered.target.querySelector('[data-testid="intersect-count"]')
+        ?.textContent,
+    ).toContain("Intersect count: 1");
+    // `once: true` in the fixture
+    expect(observer.observedElements.has(el)).toBe(false);
+  });
+
+  test("skip pauses and resumes observation", () => {
+    const rendered = render(SkipFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const toggle = rendered.target.querySelector('[data-testid="toggle-skip"]');
+    if (!el || !(toggle instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(el)).toBe(true);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(el)).toBe(false);
+    expect(MockIntersectionObserver.instances).toHaveLength(1);
+
+    toggle.click();
+    flushSync();
+    expect(observer.observedElements.has(el)).toBe(true);
+  });
+
+  test("changing rootMargin recreates the observer", () => {
+    const rendered = render(RootMarginChangeFixture);
+    cleanup = rendered.cleanup;
+    const el = rendered.target.querySelector("div");
+    const shrinkButton = rendered.target.querySelector(
+      '[data-testid="shrink-root-margin"]',
+    );
+    if (!el || !(shrinkButton instanceof HTMLButtonElement)) {
+      throw new Error("fixture markup missing");
+    }
+
+    const firstObserver = MockIntersectionObserver.last();
+    shrinkButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances).toHaveLength(2);
+    expect(firstObserver.disconnected).toBe(true);
+
+    const secondObserver = MockIntersectionObserver.last();
+    expect(secondObserver.options.rootMargin).toBe("-200px");
+    expect(secondObserver.observedElements.has(el)).toBe(true);
+  });
+});

--- a/tests/unit/missing-intersection-observer-support.test.ts
+++ b/tests/unit/missing-intersection-observer-support.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import ActionFixture from "../e2e/fixtures/ActionFixture.svelte";
+import BasicFixture from "../e2e/fixtures/BasicFixture.svelte";
+import MultipleBasicFixture from "../e2e/fixtures/MultipleBasicFixture.svelte";
+import { render } from "./render";
+
+// setup.ts's global beforeEach stubs a mocked IntersectionObserver; these
+// tests override it to be absent, matching environments without support
+// (old browsers, some SSR contexts).
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", undefined);
+});
+
+let cleanup: (() => void) | undefined;
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+});
+
+describe("missing IntersectionObserver support", () => {
+  test("IntersectionObserver component degrades gracefully without throwing", () => {
+    let rendered: ReturnType<typeof render> | undefined;
+
+    expect(() => {
+      rendered = render(BasicFixture);
+    }).not.toThrow();
+
+    cleanup = rendered?.cleanup;
+    expect(rendered?.target.querySelector("header")?.textContent).toContain(
+      "Element is not in view",
+    );
+  });
+
+  test("MultipleIntersectionObserver component degrades gracefully without throwing", () => {
+    let rendered: ReturnType<typeof render> | undefined;
+
+    expect(() => {
+      rendered = render(MultipleBasicFixture);
+    }).not.toThrow();
+
+    cleanup = rendered?.cleanup;
+    expect(
+      rendered?.target.querySelector('[data-testid="item-1-indicator"]')
+        ?.textContent,
+    ).toContain("✗");
+  });
+
+  test("intersect action degrades gracefully without throwing", () => {
+    let rendered: ReturnType<typeof render> | undefined;
+
+    expect(() => {
+      rendered = render(ActionFixture);
+    }).not.toThrow();
+
+    cleanup = rendered?.cleanup;
+    expect(rendered?.target.querySelector("header")?.textContent).toContain(
+      "Element is not in view",
+    );
+  });
+});

--- a/tests/unit/mock-intersection-observer.ts
+++ b/tests/unit/mock-intersection-observer.ts
@@ -50,6 +50,10 @@ export class MockIntersectionObserver implements IntersectionObserver {
     return this.options.rootMargin ?? "0px";
   }
 
+  get scrollMargin(): string {
+    return this.options.scrollMargin ?? "0px";
+  }
+
   get thresholds(): number[] {
     const threshold = this.options.threshold ?? 0;
     return Array.isArray(threshold) ? threshold : [threshold];

--- a/tests/unit/mock-intersection-observer.ts
+++ b/tests/unit/mock-intersection-observer.ts
@@ -1,0 +1,93 @@
+type EntryOverride = Partial<IntersectionObserverEntry> & {
+  target: Element;
+  isIntersecting: boolean;
+};
+
+/**
+ * jsdom has no native IntersectionObserver. This stand-in lets tests drive
+ * the callback with synthetic entries instead of relying on real scroll
+ * geometry (which is what the Playwright e2e suite covers).
+ */
+export class MockIntersectionObserver implements IntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  readonly callback: IntersectionObserverCallback;
+  readonly options: IntersectionObserverInit;
+  observedElements = new Set<Element>();
+  disconnected = false;
+
+  constructor(
+    callback: IntersectionObserverCallback,
+    options: IntersectionObserverInit = {},
+  ) {
+    this.callback = callback;
+    this.options = options;
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  observe(element: Element): void {
+    this.observedElements.add(element);
+  }
+
+  unobserve(element: Element): void {
+    this.observedElements.delete(element);
+  }
+
+  disconnect(): void {
+    this.observedElements.clear();
+    this.disconnected = true;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  get root(): Element | Document | null {
+    return this.options.root ?? null;
+  }
+
+  get rootMargin(): string {
+    return this.options.rootMargin ?? "0px";
+  }
+
+  get thresholds(): number[] {
+    const threshold = this.options.threshold ?? 0;
+    return Array.isArray(threshold) ? threshold : [threshold];
+  }
+
+  /** Simulate the browser invoking the callback with synthetic entries. */
+  trigger(entries: EntryOverride[]): void {
+    const fullEntries = entries.map(({ target, isIntersecting, ...rest }) => {
+      const entry: IntersectionObserverEntry = {
+        target,
+        isIntersecting,
+        intersectionRatio: isIntersecting ? 1 : 0,
+        boundingClientRect: target.getBoundingClientRect(),
+        intersectionRect: target.getBoundingClientRect(),
+        rootBounds: null,
+        time: 0,
+        ...rest,
+      };
+
+      return entry;
+    });
+
+    this.callback(fullEntries, this);
+  }
+
+  static reset(): void {
+    MockIntersectionObserver.instances = [];
+  }
+
+  /** The most recently constructed instance — components in this repo only ever hold one at a time. */
+  static last(): MockIntersectionObserver {
+    const instance =
+      MockIntersectionObserver.instances[
+        MockIntersectionObserver.instances.length - 1
+      ];
+
+    if (!instance) throw new Error("No MockIntersectionObserver was created.");
+
+    return instance;
+  }
+}

--- a/tests/unit/render.ts
+++ b/tests/unit/render.ts
@@ -1,0 +1,16 @@
+import { type Component, flushSync, mount, unmount } from "svelte";
+
+/** Mounts a fixture into a detached container and returns a matching cleanup function. */
+export function render(Component: Component) {
+  const target = document.createElement("div");
+  document.body.appendChild(target);
+  const instance = flushSync(() => mount(Component, { target }));
+
+  return {
+    target,
+    cleanup: () => {
+      unmount(instance);
+      target.remove();
+    },
+  };
+}

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,11 @@
+import { afterEach, beforeEach, vi } from "vitest";
+import { MockIntersectionObserver } from "./mock-intersection-observer";
+
+beforeEach(() => {
+  MockIntersectionObserver.reset();
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "package.json"), "utf-8"),
+);
+
+export default defineConfig({
+  plugins: [svelte({ preprocess: vitePreprocess() })],
+  resolve: {
+    // Match Svelte's own recommendation for testing runes-based code: force
+    // the browser build so component internals behave as they do at runtime.
+    conditions: ["browser"],
+    alias: {
+      [pkg.name]: path.resolve(__dirname, pkg.svelte),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    include: ["tests/unit/**/*.test.ts"],
+    setupFiles: ["./tests/unit/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds Vitest + jsdom alongside the existing Playwright e2e suite, using a mocked `IntersectionObserver` to drive synthetic intersection entries deterministically instead of relying on real scroll geometry
- Reuses the existing e2e fixtures (`tests/e2e/fixtures/*.svelte`) as mount targets so component markup has a single source of truth across both suites
- Covers the `intersect` action/attachment's `update()`/`destroy()` branch logic, and both `IntersectionObserver.svelte` and `MultipleIntersectionObserver.svelte`'s observe/unobserve wiring, `once`, `skip`, element/elements diffing, and root/rootMargin/threshold reconfiguration
- Wires `test:unit` into CI alongside lint/type-check (no browser needed)