### PR TITLE
ci: verify docs build on PRs; upgrade to TypeScript 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Check types
         run: bun run test:types
 
+      - name: Build documentation
+        run: bun run build
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "svelte": "5.56.4",
         "svelte-check": "^4.7.1",
         "svelte-readme": "^4.3.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vite": "^8.1.3",
       },
     },
@@ -198,7 +198,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "svelte": "5.56.4",
     "svelte-check": "^4.7.1",
     "svelte-readme": "^4.3.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vite": "^8.1.3"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- Add a "Build documentation" step to the `checks` CI job so a broken docs build fails on every PR/push, not just when `deploy-docs` runs on master
- Upgrade `typescript` from `^5.9.3` to `^6.0.3`

## Test plan
- [x] `bun run test:types` — 0 errors
- [x] `bun run build` — docs site builds successfully
- [x] `bunx biome ci --error-on-warnings` — passes