### PR TITLE
fix(intersect): guard createIntersectionGroup against missing IntersectionObserver

### DIFF
--- a/src/intersect.svelte.js
+++ b/src/intersect.svelte.js
@@ -128,7 +128,7 @@ export function createIntersectionGroup(getSharedOptions = () => ({})) {
    */
   function attach(nodeOptions = {}) {
     return (/** @type {Element} */ node) => {
-      if (!observer) {
+      if (!observer && typeof IntersectionObserver !== "undefined") {
         const {
           root = null,
           rootMargin = "0px",
@@ -142,7 +142,7 @@ export function createIntersectionGroup(getSharedOptions = () => ({})) {
       }
 
       callbacks.set(node, nodeOptions);
-      if (!nodeOptions.skip) observer.observe(node);
+      if (!nodeOptions.skip) observer?.observe(node);
 
       return () => {
         observer?.unobserve(node);

--- a/tests/unit/missing-intersection-observer-support.test.ts
+++ b/tests/unit/missing-intersection-observer-support.test.ts
@@ -64,11 +64,9 @@ describe("missing IntersectionObserver support", () => {
     const group = createIntersectionGroup();
     const node = document.createElement("div");
 
-    let detach: (() => void) | undefined;
     expect(() => {
-      detach = group.attach()(node);
+      const detach = group.attach()(node);
+      detach?.();
     }).not.toThrow();
-
-    expect(() => detach?.()).not.toThrow();
   });
 });

--- a/tests/unit/missing-intersection-observer-support.test.ts
+++ b/tests/unit/missing-intersection-observer-support.test.ts
@@ -1,3 +1,4 @@
+import { createIntersectionGroup } from "svelte-intersection-observer";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import ActionFixture from "../e2e/fixtures/ActionFixture.svelte";
 import BasicFixture from "../e2e/fixtures/BasicFixture.svelte";
@@ -57,5 +58,17 @@ describe("missing IntersectionObserver support", () => {
     expect(rendered?.target.querySelector("header")?.textContent).toContain(
       "Element is not in view",
     );
+  });
+
+  test("createIntersectionGroup degrades gracefully without throwing", () => {
+    const group = createIntersectionGroup();
+    const node = document.createElement("div");
+
+    let detach: (() => void) | undefined;
+    expect(() => {
+      detach = group.attach()(node);
+    }).not.toThrow();
+
+    expect(() => detach?.()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- `createIntersectionGroup`'s `attach()` called `new IntersectionObserver(...)` unconditionally, unlike the `intersect` action and the `IntersectionObserver`/`MultipleIntersectionObserver` components, which all guard with `typeof IntersectionObserver === "undefined"` before constructing one — this would throw in SSR/non-browser environments.
- Adds the same guard, and makes the subsequent `.observe(node)` call optional-chained.
- Adds a test to the missing-support suite covering `createIntersectionGroup` degrading gracefully.