### PR TITLE
test: add expectTypeOf coverage for src/* type exports

### DIFF
--- a/tests/unit/types.test-d.ts
+++ b/tests/unit/types.test-d.ts
@@ -1,0 +1,126 @@
+import type { Component, ComponentProps } from "svelte";
+import type { Action } from "svelte/action";
+import type { Attachment } from "svelte/attachments";
+import type {
+  IntersectActionOptions,
+  IntersectGroupNodeOptions,
+  IntersectGroupSharedOptions,
+  IntersectionGroup,
+  IntersectionObserverState,
+} from "svelte-intersection-observer";
+import IntersectionObserverComponent, {
+  createIntersectionGroup,
+  createIntersectionObserver,
+  intersect,
+  intersectAttachment,
+  MultipleIntersectionObserver,
+} from "svelte-intersection-observer";
+import type { IntersectionObserverProps } from "svelte-intersection-observer/IntersectionObserver.svelte";
+import type { MultipleIntersectionObserverProps } from "svelte-intersection-observer/MultipleIntersectionObserver.svelte";
+import { expectTypeOf, test } from "vitest";
+
+test("IntersectActionOptions accepts the documented shape", () => {
+  expectTypeOf<IntersectActionOptions>().toEqualTypeOf<{
+    root?: null | HTMLElement;
+    rootMargin?: string;
+    threshold?: number | number[];
+    once?: boolean;
+    skip?: boolean;
+  }>();
+});
+
+test("intersect is a Svelte action dispatching observe/intersect handlers", () => {
+  expectTypeOf(intersect).toEqualTypeOf<
+    Action<
+      HTMLElement,
+      IntersectActionOptions | undefined,
+      {
+        onobserve?: (event: CustomEvent<IntersectionObserverEntry>) => void;
+        onintersect?: (
+          event: CustomEvent<
+            IntersectionObserverEntry & { isIntersecting: true }
+          >,
+        ) => void;
+      }
+    >
+  >();
+});
+
+test("intersectAttachment returns an Attachment<HTMLElement>", () => {
+  expectTypeOf(intersectAttachment).toEqualTypeOf<
+    (getOptions?: () => IntersectActionOptions) => Attachment<HTMLElement>
+  >();
+});
+
+test("IntersectGroupSharedOptions covers only the observer-wide options", () => {
+  expectTypeOf<IntersectGroupSharedOptions>().toEqualTypeOf<{
+    root?: null | HTMLElement;
+    rootMargin?: string;
+    threshold?: number | number[];
+  }>();
+});
+
+test("IntersectGroupNodeOptions covers only the per-node options", () => {
+  expectTypeOf<IntersectGroupNodeOptions>().toEqualTypeOf<{
+    once?: boolean;
+    skip?: boolean;
+    onobserve?: (entry: IntersectionObserverEntry) => void;
+    onintersect?: (
+      entry: IntersectionObserverEntry & { isIntersecting: true },
+    ) => void;
+  }>();
+});
+
+test("IntersectionGroup.attach accepts node options and returns an Attachment", () => {
+  expectTypeOf<IntersectionGroup>()
+    .toHaveProperty("attach")
+    .toEqualTypeOf<
+      (options?: IntersectGroupNodeOptions) => Attachment<HTMLElement>
+    >();
+});
+
+test("createIntersectionGroup returns an IntersectionGroup", () => {
+  expectTypeOf(createIntersectionGroup).toEqualTypeOf<
+    (getSharedOptions?: () => IntersectGroupSharedOptions) => IntersectionGroup
+  >();
+});
+
+test("IntersectionObserverState exposes readonly intersecting/entry and an attach Attachment", () => {
+  expectTypeOf<IntersectionObserverState>().toEqualTypeOf<{
+    readonly intersecting: boolean;
+    readonly entry: null | IntersectionObserverEntry;
+    attach: Attachment<HTMLElement>;
+  }>();
+});
+
+test("createIntersectionObserver returns an IntersectionObserverState", () => {
+  expectTypeOf(createIntersectionObserver).toEqualTypeOf<
+    (getOptions?: () => IntersectActionOptions) => IntersectionObserverState
+  >();
+});
+
+test("default export is the IntersectionObserver component with its bindable props", () => {
+  expectTypeOf(IntersectionObserverComponent).toEqualTypeOf<
+    Component<
+      IntersectionObserverProps,
+      Record<string, never>,
+      "intersecting" | "entry" | "observer"
+    >
+  >();
+  expectTypeOf<
+    ComponentProps<typeof IntersectionObserverComponent>
+  >().toEqualTypeOf<IntersectionObserverProps>();
+});
+
+test("MultipleIntersectionObserver component exposes its bindable props", () => {
+  expectTypeOf(MultipleIntersectionObserver).toEqualTypeOf<
+    Component<
+      MultipleIntersectionObserverProps,
+      Record<string, never>,
+      "elementIntersections" | "elementEntries" | "observer"
+    >
+  >();
+  expectTypeOf<
+    ComponentProps<typeof MultipleIntersectionObserver>
+  >().toEqualTypeOf<MultipleIntersectionObserverProps>();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,5 +23,9 @@ export default defineConfig({
     environment: "jsdom",
     include: ["tests/unit/**/*.test.ts"],
     setupFiles: ["./tests/unit/setup.ts"],
+    typecheck: {
+      enabled: true,
+      include: ["tests/unit/**/*.test-d.ts"],
+    },
   },
 });


### PR DESCRIPTION
Adds a type-level test suite (tests/unit/types.test-d.ts) that uses Vitest's expectTypeOf to assert on every exported type and function signature from src/*: IntersectActionOptions, IntersectGroupSharedOptions, IntersectGroupNodeOptions, IntersectionGroup, the intersect action, intersectAttachment, createIntersectionGroup, IntersectionObserverState, createIntersectionObserver, and the props/bindings of both the IntersectionObserver and MultipleIntersectionObserver components. Imports use the real package subpaths (e.g. svelte-intersection-observer/IntersectionObserver.svelte) via the existing tsconfig path mapping, rather than relative paths into src.

vitest.config.ts now enables typecheck, scoped to tests/unit/**/*.test-d.ts, so these run alongside the regular suite in a single vitest run/test:unit invocation with no separate command needed.

Low risk: this only adds a new test file and a scoped config option. The main thing to watch is that the typecheck runner adds a bit of extra time to test:unit (a few seconds, spawns tsc), and that future changes to the public type exports will now fail CI if they drift from these assertions, which is the intended effect.