### PR TITLE
chore(package): declare svelte peer dependency and sideEffects: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See [Library](#library) for the full docs on each. Try it in the [Svelte REPL](h
 | Package version | Svelte version    | Notes                                     |
 | :--------------- | :----------------- | :----------------------------------------- |
 | [1.x](https://github.com/metonym/svelte-intersection-observer/tree/v1.2.x) | 3, 4, 5 (non-runes) | Uses `export let`, slots, and `on:` events |
-| 2.x              | 5 (runes mode only) | Uses `$props()`, snippets, and callback props |
+| 2.x              | ≥5.29 (runes mode only) | Uses `$props()`, snippets, and callback props |
 
 <!-- TOC -->
 

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -36,6 +36,11 @@ pkgJson.exports = {
   },
 };
 
+pkgJson.sideEffects = false;
+pkgJson.peerDependencies = {
+  svelte: "^5.29.0",
+};
+
 await Bun.write("./package/package.json", JSON.stringify(pkgJson, null, 2));
 
 /** Comment ranges (byte offsets, delimiters included) found in a source string. */


### PR DESCRIPTION
The published package.json is generated by scripts/npm-package.ts and never declared a peerDependencies entry for svelte, so package managers couldn't warn on incompatible installs. The actual floor is svelte 5.29: index.js re-exports from intersect.svelte.js, which imports fromAction from svelte/attachments at module top level, so every entry point requires it even for consumers who only use the component.

This adds peerDependencies.svelte set to ^5.29.0 and sideEffects set to false to the generated manifest in scripts/npm-package.ts. All modules in the package are pure (no top-level DOM or global mutation, and the svelte/elements module augmentation is types-only), so marking the package side-effect-free lets bundlers tree-shake unused primitives like MultipleIntersectionObserver when an app only uses the intersect action.

Also updated the README compatibility table to say the 2.x row requires svelte >=5.29 instead of just 5, matching the new peer range.

Risk is low. This only changes metadata in the generated package.json (peerDependencies and sideEffects) and a doc table, no runtime code changed. Consumers on svelte 5.28 or earlier who were previously installing without warning will now see a peer dependency warning, which is the intended behavior since those versions don't actually work.