### PR TITLE
fix: unobserve `entry.target` for `once`, not the current element prop

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -63,7 +63,7 @@
               ),
             );
 
-            if (element && once) observer?.unobserve(element);
+            if (once) observer?.unobserve(_entry.target);
           }
         }
       },

--- a/tests/e2e/fixtures/OnceElementChangeFixture.svelte
+++ b/tests/e2e/fixtures/OnceElementChangeFixture.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let element: null | HTMLDivElement = null;
+  let elementB: null | HTMLDivElement = null;
+  let intersecting = false;
+</script>
+
+<header class:intersecting>
+  {intersecting ? "Element is in view" : "Element is not in view"}
+  <button
+    data-testid="switch"
+    onclick={() => (element = elementB)}
+  >
+    Switch
+  </button>
+</header>
+
+<IntersectionObserver
+  {element}
+  bind:intersecting
+  once
+>
+  <div
+    data-testid="el-a"
+    bind:this={element}
+  >
+    A
+  </div>
+</IntersectionObserver>
+
+<div
+  data-testid="el-b"
+  bind:this={elementB}
+>
+  B
+</div>
+
+<style>
+  header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 1rem;
+    background-color: #e0f7f6;
+  }
+
+  [data-testid="el-a"] {
+    height: 38vh;
+    padding: 1rem;
+    background-color: #376462;
+    color: #fff;
+  }
+
+  [data-testid="el-b"] {
+    margin-top: calc(100vh + 1px);
+    height: 38vh;
+    padding: 1rem;
+    background-color: #2ecc71;
+    color: #fff;
+  }
+</style>

--- a/tests/unit/IntersectionObserver.test.ts
+++ b/tests/unit/IntersectionObserver.test.ts
@@ -4,6 +4,7 @@ import BasicFixture from "../e2e/fixtures/BasicFixture.svelte";
 import EachBindingFixture from "../e2e/fixtures/EachBindingFixture.svelte";
 import ElementChangeFixture from "../e2e/fixtures/ElementChangeFixture.svelte";
 import ElementNullFixture from "../e2e/fixtures/ElementNullFixture.svelte";
+import OnceElementChangeFixture from "../e2e/fixtures/OnceElementChangeFixture.svelte";
 import OnceFixture from "../e2e/fixtures/OnceFixture.svelte";
 import RootFixture from "../e2e/fixtures/RootFixture.svelte";
 import RootMarginChangeFixture from "../e2e/fixtures/RootMarginChangeFixture.svelte";
@@ -78,6 +79,36 @@ describe("IntersectionObserver", () => {
       rendered.target.querySelector('[data-testid="intersect-count"]')
         ?.textContent,
     ).toContain("Intersect count: 1");
+  });
+
+  test("once unobserves the entry's own target, not a stale element prop, when the element changes before delivery", () => {
+    const rendered = render(OnceElementChangeFixture);
+    cleanup = rendered.cleanup;
+    const elementA = rendered.target.querySelector('[data-testid="el-a"]');
+    const elementB = rendered.target.querySelector('[data-testid="el-b"]');
+    const switchButton = rendered.target.querySelector(
+      '[data-testid="switch"]',
+    );
+    if (
+      !elementA ||
+      !elementB ||
+      !(switchButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const observer = MockIntersectionObserver.last();
+    expect(observer.observedElements.has(elementA)).toBe(true);
+
+    switchButton.click();
+    flushSync();
+
+    flushSync(() =>
+      observer.trigger([{ target: elementA, isIntersecting: true }]),
+    );
+
+    expect(observer.observedElements.has(elementB)).toBe(true);
+    expect(observer.observedElements.has(elementA)).toBe(false);
   });
 
   test("skip pauses and resumes observation without losing state", () => {


### PR DESCRIPTION
The once callback in IntersectionObserver.svelte was unobserving the current element prop rather than the entry's own target. Since IntersectionObserver callbacks are delivered asynchronously, a stale entry could arrive after the element prop had already changed, causing unobserve to run against the new element instead of the one the entry actually belonged to. That left the new element unobserved and the old one potentially still observed, silently breaking the wiring after a fast element swap with once set.

The fix unobserves entry.target directly, matching the approach already used in MultipleIntersectionObserver and createIntersectionGroup.

Added a fixture and unit test that reproduce the race by swapping the observed element and then delivering a stale entry for the old element, confirming the new element stays observed and the old one does not. The test fails against the prior implementation and passes with the fix. Risk is low since the change only affects the once code path and mirrors existing, already-correct behavior elsewhere in the codebase.