### PR TITLE
fix: recreate observer when `root` changes to a same-tag element

### DIFF
--- a/src/IntersectionObserver.svelte
+++ b/src/IntersectionObserver.svelte
@@ -38,9 +38,7 @@
 
   let prevSkip = untrack(() => skip);
 
-  const configKey = $derived(
-    `${root}|${rootMargin}|${JSON.stringify(threshold)}`,
-  );
+  const configKey = $derived(`${rootMargin}|${JSON.stringify(threshold)}`);
 
   const initialize = () => {
     if (typeof IntersectionObserver === "undefined") {
@@ -73,6 +71,7 @@
 
   $effect(() => {
     configKey;
+    root;
 
     untrack(() => {
       prevElement = null;

--- a/src/MultipleIntersectionObserver.svelte
+++ b/src/MultipleIntersectionObserver.svelte
@@ -38,9 +38,7 @@
 
   let prevSkip = untrack(() => skip);
 
-  const configKey = $derived(
-    `${root}|${rootMargin}|${JSON.stringify(threshold)}`,
-  );
+  const configKey = $derived(`${rootMargin}|${JSON.stringify(threshold)}`);
 
   const initialize = () => {
     if (typeof IntersectionObserver === "undefined") {
@@ -80,6 +78,7 @@
 
   $effect(() => {
     configKey;
+    root;
 
     untrack(() => {
       prevElements = new Set();

--- a/tests/e2e/fixtures/MultipleRootChangeFixture.svelte
+++ b/tests/e2e/fixtures/MultipleRootChangeFixture.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { MultipleIntersectionObserver } from "svelte-intersection-observer";
+
+  let containerA: null | HTMLDivElement = null;
+  let containerB: null | HTMLDivElement = null;
+  let ref1: null | HTMLDivElement = null;
+  let ref2: null | HTMLDivElement = null;
+  let root: null | HTMLDivElement = null;
+
+  $: elements = [ref1, ref2];
+  $: if (!root && containerA) root = containerA;
+</script>
+
+<div
+  bind:this={containerA}
+  data-testid="root-a"
+  style="height: 200px; overflow-y: auto;"
+></div>
+
+<div
+  bind:this={containerB}
+  data-testid="root-b"
+  style="height: 200px; overflow-y: auto;"
+></div>
+
+<button
+  data-testid="swap-root"
+  onclick={() => (root = containerB)}
+>
+  Swap root
+</button>
+
+<MultipleIntersectionObserver
+  {elements}
+  {root}
+>
+  {#snippet children()}
+    <div
+      bind:this={ref1}
+      data-testid="item-1"
+    >
+      Item 1
+    </div>
+    <div
+      bind:this={ref2}
+      data-testid="item-2"
+    >
+      Item 2
+    </div>
+  {/snippet}
+</MultipleIntersectionObserver>

--- a/tests/e2e/fixtures/RootChangeFixture.svelte
+++ b/tests/e2e/fixtures/RootChangeFixture.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import IntersectionObserver from "svelte-intersection-observer";
+
+  let containerA: null | HTMLDivElement = null;
+  let containerB: null | HTMLDivElement = null;
+  let element: null | HTMLDivElement = null;
+  let root: null | HTMLDivElement = null;
+
+  $: if (!root && containerA) root = containerA;
+</script>
+
+<div
+  bind:this={containerA}
+  data-testid="root-a"
+  style="height: 200px; overflow-y: auto;"
+></div>
+
+<div
+  bind:this={containerB}
+  data-testid="root-b"
+  style="height: 200px; overflow-y: auto;"
+></div>
+
+<button
+  data-testid="swap-root"
+  onclick={() => (root = containerB)}
+>
+  Swap root
+</button>
+
+<IntersectionObserver
+  {element}
+  {root}
+>
+  <div
+    bind:this={element}
+    data-testid="element"
+  >
+    Hello world
+  </div>
+</IntersectionObserver>

--- a/tests/unit/IntersectionObserver.test.ts
+++ b/tests/unit/IntersectionObserver.test.ts
@@ -5,6 +5,7 @@ import EachBindingFixture from "../e2e/fixtures/EachBindingFixture.svelte";
 import ElementChangeFixture from "../e2e/fixtures/ElementChangeFixture.svelte";
 import ElementNullFixture from "../e2e/fixtures/ElementNullFixture.svelte";
 import OnceFixture from "../e2e/fixtures/OnceFixture.svelte";
+import RootChangeFixture from "../e2e/fixtures/RootChangeFixture.svelte";
 import RootFixture from "../e2e/fixtures/RootFixture.svelte";
 import RootMarginChangeFixture from "../e2e/fixtures/RootMarginChangeFixture.svelte";
 import RootMarginFixture from "../e2e/fixtures/RootMarginFixture.svelte";
@@ -189,6 +190,41 @@ describe("IntersectionObserver", () => {
     if (!container) throw new Error("fixture markup missing");
 
     expect(MockIntersectionObserver.last().options.root).toBe(container);
+  });
+
+  test("changing root to a different element of the same tag recreates the observer", () => {
+    const rendered = render(RootChangeFixture);
+    cleanup = rendered.cleanup;
+    const containerA = rendered.target.querySelector('[data-testid="root-a"]');
+    const containerB = rendered.target.querySelector('[data-testid="root-b"]');
+    const element = rendered.target.querySelector('[data-testid="element"]');
+    const swapButton = rendered.target.querySelector(
+      '[data-testid="swap-root"]',
+    );
+    if (
+      !containerA ||
+      !containerB ||
+      !element ||
+      !(swapButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const instanceCountBefore = MockIntersectionObserver.instances.length;
+    const firstObserver = MockIntersectionObserver.last();
+    expect(firstObserver.root).toBe(containerA);
+
+    swapButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances.length).toBe(
+      instanceCountBefore + 1,
+    );
+    expect(firstObserver.disconnected).toBe(true);
+
+    const secondObserver = MockIntersectionObserver.last();
+    expect(secondObserver.root).toBe(containerB);
+    expect(secondObserver.observedElements.has(element)).toBe(true);
   });
 
   test("each block instances get independent observers", () => {

--- a/tests/unit/MultipleIntersectionObserver.test.ts
+++ b/tests/unit/MultipleIntersectionObserver.test.ts
@@ -5,6 +5,7 @@ import MultipleBindingFixture from "../e2e/fixtures/MultipleBindingFixture.svelt
 import MultipleElementsChangeFixture from "../e2e/fixtures/MultipleElementsChangeFixture.svelte";
 import MultipleFixture from "../e2e/fixtures/MultipleFixture.svelte";
 import MultipleOnceFixture from "../e2e/fixtures/MultipleOnceFixture.svelte";
+import MultipleRootChangeFixture from "../e2e/fixtures/MultipleRootChangeFixture.svelte";
 import MultipleRootFixture from "../e2e/fixtures/MultipleRootFixture.svelte";
 import MultipleRootMarginChangeFixture from "../e2e/fixtures/MultipleRootMarginChangeFixture.svelte";
 import MultipleSkipFixture from "../e2e/fixtures/MultipleSkipFixture.svelte";
@@ -216,6 +217,44 @@ describe("MultipleIntersectionObserver", () => {
     if (!container) throw new Error("fixture markup missing");
 
     expect(MockIntersectionObserver.last().options.root).toBe(container);
+  });
+
+  test("changing root to a different element of the same tag recreates the observer and re-observes all elements", () => {
+    const rendered = render(MultipleRootChangeFixture);
+    cleanup = rendered.cleanup;
+    const containerA = rendered.target.querySelector('[data-testid="root-a"]');
+    const containerB = rendered.target.querySelector('[data-testid="root-b"]');
+    const item1 = rendered.target.querySelector('[data-testid="item-1"]');
+    const item2 = rendered.target.querySelector('[data-testid="item-2"]');
+    const swapButton = rendered.target.querySelector(
+      '[data-testid="swap-root"]',
+    );
+    if (
+      !containerA ||
+      !containerB ||
+      !item1 ||
+      !item2 ||
+      !(swapButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("fixture markup missing");
+    }
+
+    const instanceCountBefore = MockIntersectionObserver.instances.length;
+    const firstObserver = MockIntersectionObserver.last();
+    expect(firstObserver.root).toBe(containerA);
+
+    swapButton.click();
+    flushSync();
+
+    expect(MockIntersectionObserver.instances.length).toBe(
+      instanceCountBefore + 1,
+    );
+    expect(firstObserver.disconnected).toBe(true);
+
+    const secondObserver = MockIntersectionObserver.last();
+    expect(secondObserver.root).toBe(containerB);
+    expect(secondObserver.observedElements.has(item1)).toBe(true);
+    expect(secondObserver.observedElements.has(item2)).toBe(true);
   });
 
   test("changing rootMargin recreates the observer and re-observes current elements", () => {


### PR DESCRIPTION
The observer re-init key in both IntersectionObserver.svelte and MultipleIntersectionObserver.svelte was built by string-interpolating root along with rootMargin and threshold. An HTMLElement stringifies to its tag form, e.g. "[object HTMLDivElement]", so swapping root between two elements of the same tag (two divs, for example) produced an identical key. The effect that tears down and recreates the native IntersectionObserver never re-ran, and the observer kept measuring intersections against the old root element.

The fix narrows the derived key to the value-typed options (rootMargin and threshold) and reads root directly in the re-init effect body, outside untrack, so a reference change to root now correctly triggers teardown and recreation. initialize() already read root when constructing the observer, so no change was needed there. The intersect action was already comparing root by reference and is unaffected.

Added unit tests for both components that swap root between two same-tag containers and assert a new observer instance is created, the old one is disconnected, and elements are re-observed against the new root. Confirmed the tests fail against the pre-fix code and pass after the fix. Full unit, type-check, lint, and e2e suites pass.

Risk is low and scoped to the reactive wiring around root changes. Anyone relying on the old (buggy) behavior where changing root to a same-tag element silently kept the previous root would see a behavior change, but that behavior was never intentional or documented.